### PR TITLE
feat: 增量 Wiki 更新、Git 待同步提交查看器、选择性 Wiki 页面重新生成

### DIFF
--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -511,3 +511,47 @@ async def read_repository_file(
         "total_lines": total_lines,
         "language": language,
     }
+
+
+@router.get(
+    "/{repo_id}/pending-commits",
+    summary="获取远程仓库待同步的提交列表",
+)
+async def get_pending_commits(
+    repo_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    执行 git fetch 后，返回 HEAD..origin/{branch} 之间尚未同步的提交列表。
+    用于在增量同步弹窗中展示「本次将同步哪些提交」。
+    不启动 Celery 任务，仅做只读查询。
+    """
+    repo = await db.get(Repository, repo_id)
+    if not repo:
+        raise HTTPException(status_code=404, detail="仓库不存在")
+    if not repo.local_path:
+        raise HTTPException(status_code=400, detail="仓库尚未克隆")
+
+    import asyncio as _asyncio
+    from app.tasks.incremental_sync import get_pending_commits as _get_commits
+
+    branch = repo.default_branch or "main"
+    local_path = repo.local_path
+
+    try:
+        commits = await _asyncio.wait_for(
+            _get_commits(local_path, branch),
+            timeout=60.0,
+        )
+    except _asyncio.TimeoutError:
+        raise HTTPException(status_code=504, detail="获取提交列表超时")
+    except Exception as e:
+        logger.warning(f"[RepoAPI] 获取 pending commits 失败: {e}")
+        raise HTTPException(status_code=500, detail=f"获取提交列表失败: {e}")
+
+    return {
+        "repo_id": repo_id,
+        "branch": branch,
+        "count": len(commits),
+        "commits": commits,
+    }

--- a/app/api/repositories.py
+++ b/app/api/repositories.py
@@ -546,8 +546,8 @@ async def get_pending_commits(
     except _asyncio.TimeoutError:
         raise HTTPException(status_code=504, detail="获取提交列表超时")
     except Exception as e:
-        logger.warning(f"[RepoAPI] 获取 pending commits 失败: {e}")
-        raise HTTPException(status_code=500, detail=f"获取提交列表失败: {e}")
+        logger.exception(f"[RepoAPI] 获取 pending commits 失败: {type(e).__name__}: {e}")
+        raise HTTPException(status_code=500, detail=f"获取提交列表失败: {type(e).__name__}: {e}")
 
     return {
         "repo_id": repo_id,

--- a/app/api/wiki.py
+++ b/app/api/wiki.py
@@ -106,6 +106,7 @@ async def regenerate_wiki(
         repo_url=repo.url,
         llm_provider=request.llm_provider,
         llm_model=request.llm_model,
+        pages=request.pages,
     )
     task.celery_task_id = celery_result.id
     await db.commit()

--- a/app/services/llm/dashscope_adapter.py
+++ b/app/services/llm/dashscope_adapter.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 from typing import AsyncIterator, List, Optional
 
-from openai import AsyncOpenAI, RateLimitError
+from openai import AsyncOpenAI, RateLimitError, APIConnectionError, InternalServerError
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 
 from app.services.llm.adapter import BaseLLMAdapter
@@ -38,7 +38,7 @@ class DashScopeAdapter(BaseLLMAdapter):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=2, max=30),
-        retry=retry_if_exception_type((RateLimitError, TimeoutError, ConnectionError, asyncio.TimeoutError)),
+        retry=retry_if_exception_type((RateLimitError, TimeoutError, ConnectionError, asyncio.TimeoutError, APIConnectionError, InternalServerError)),
         before_sleep=lambda state: logger.warning(
             f"[DashScopeAdapter] 重试第 {state.attempt_number} 次"
         ),

--- a/app/services/llm/gemini_adapter.py
+++ b/app/services/llm/gemini_adapter.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 from typing import AsyncIterator, List, Optional
 
-from openai import AsyncOpenAI, RateLimitError
+from openai import AsyncOpenAI, RateLimitError, APIConnectionError, InternalServerError
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 
 from app.services.llm.adapter import BaseLLMAdapter
@@ -36,7 +36,7 @@ class GeminiAdapter(BaseLLMAdapter):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=2, max=30),
-        retry=retry_if_exception_type((RateLimitError, TimeoutError, ConnectionError, asyncio.TimeoutError)),
+        retry=retry_if_exception_type((RateLimitError, TimeoutError, ConnectionError, asyncio.TimeoutError, APIConnectionError, InternalServerError)),
         before_sleep=lambda state: logger.warning(
             f"[GeminiAdapter] 重试第 {state.attempt_number} 次"
         ),

--- a/app/services/llm/openai_adapter.py
+++ b/app/services/llm/openai_adapter.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import AsyncIterator, List, Optional
 
-from openai import AsyncOpenAI, RateLimitError, APIStatusError
+from openai import AsyncOpenAI, RateLimitError, APIStatusError, APIConnectionError, InternalServerError
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 
 from app.services.llm.adapter import BaseLLMAdapter
@@ -24,7 +24,7 @@ class OpenAIAdapter(BaseLLMAdapter):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=2, max=30),
-        retry=retry_if_exception_type((RateLimitError, TimeoutError, ConnectionError, asyncio.TimeoutError)),
+        retry=retry_if_exception_type((RateLimitError, TimeoutError, ConnectionError, asyncio.TimeoutError, APIConnectionError, InternalServerError)),
         before_sleep=lambda state: logger.warning(
             f"[OpenAIAdapter] 重试第 {state.attempt_number} 次"
         ),

--- a/app/services/wiki_generator.py
+++ b/app/services/wiki_generator.py
@@ -341,10 +341,10 @@ async def generate_wiki(
     llm_model: Optional[str] = None,
     progress_callback: Optional[Callable] = None,
     cancel_checker: Optional[Callable] = None,
-) -> str:
+) -> dict:
     """
     Wiki 生成主流程。
-    返回: wiki_id
+    返回: {"wiki_id": str, "total_pages": int, "skipped_pages": int}
     """
     from app.config import settings
     adapter = create_adapter(llm_provider)
@@ -400,7 +400,7 @@ async def generate_wiki(
     if total_pages == 0:
         logger.warning("[WikiGenerator] 大纲中无任何页面，跳过内容生成")
         await db.flush()
-        return wiki.id
+        return {"wiki_id": wiki.id, "total_pages": 0, "skipped_pages": 0}
 
     logger.info(
         f"[WikiGenerator] 开始生成页面内容: 共 {total_pages} 页"
@@ -442,6 +442,7 @@ async def generate_wiki(
     # 2b: 串行写入 DB（保持 AsyncSession 单协程使用，避免并发冲突）
     section_map: Dict[str, WikiSection] = {}
     page_count = 0
+    skipped_count = 0
 
     for (s_data, p_data), result in zip(task_meta, results):
         section_title = s_data["title"]
@@ -461,6 +462,7 @@ async def generate_wiki(
             logger.error(
                 f"[WikiGenerator] 页面生成失败，跳过: {p_data['title']} — {result}"
             )
+            skipped_count += 1
             continue
 
         _, _, content = result
@@ -479,8 +481,14 @@ async def generate_wiki(
             await progress_callback(pct, f"写入页面 ({page_count}/{total_pages}): {p_data['title']}")
         await db.commit()  # 每页提交一次，释放写锁，允许并发写入（如 DELETE）
 
-    logger.info(f"[WikiGenerator] Wiki 生成完成: wiki_id={wiki.id}")
-    return wiki.id
+    if skipped_count:
+        logger.warning(
+            f"[WikiGenerator] Wiki 生成完成（含跳过页）: wiki_id={wiki.id} "
+            f"成功={page_count} 跳过={skipped_count} 共={total_pages}"
+        )
+    else:
+        logger.info(f"[WikiGenerator] Wiki 生成完成: wiki_id={wiki.id} 共={total_pages} 页")
+    return {"wiki_id": wiki.id, "total_pages": total_pages, "skipped_pages": skipped_count}
 
 
 async def _plan_page(
@@ -1007,4 +1015,265 @@ def _default_outline(title: str = "Wiki") -> dict:
                 ],
             }
         ],
+    }
+
+
+# ============================================================
+# 增量 Wiki 更新（真正的增量，仅更新受变更影响的页面）
+# ============================================================
+
+async def _suggest_section_title(
+    adapter, model: str, current_title: str, page_titles: List[str], repo_name: str
+) -> Optional[str]:
+    """
+    当一个章节的大多数页面都需要更新时，询问 LLM 是否需要更改章节标题。
+    如果建议保持原标题则返回 None，否则返回新标题。
+    """
+    messages = [
+        LLMMessage(role="user", content=(
+            f"Repository: {repo_name}\n"
+            f"Current section title: {current_title}\n"
+            f"Pages in this section:\n" +
+            "\n".join(f"- {t}" for t in page_titles) +
+            "\n\nThe code in this section has been significantly updated. "
+            "Does the section title still accurately describe its content? "
+            "If yes, reply ONLY with the word KEEP. "
+            "If the title should be updated, reply with ONLY the new title (no quotes, no explanation, max 60 chars)."
+        )),
+    ]
+    try:
+        resp = await adapter.generate_with_rate_limit(messages=messages, model=model, temperature=0.1)
+        result = resp.content.strip()
+        if result.upper() == "KEEP" or not result:
+            return None
+        # Sanity check: title must be reasonable length
+        if len(result) > 80:
+            return None
+        return result
+    except Exception as e:
+        logger.warning(f"[WikiIncrUpdate] 章节标题建议失败: {e}")
+        return None
+
+
+async def update_wiki_incrementally(
+    db: AsyncSession,
+    repo_id: str,
+    changed_files: List[str],
+    llm_provider: Optional[str] = None,
+    llm_model: Optional[str] = None,
+    progress_callback: Optional[Callable] = None,
+    cancel_checker: Optional[Callable] = None,
+) -> dict:
+    """
+    真正的增量 Wiki 更新：只更新受变更文件影响的页面，保留未受影响的内容。
+
+    策略：
+    - 通过 WikiPage.relevant_files 与 changed_files 交集找出"脏页"
+    - 脏页比例 <= 65%：只更新脏页，可弹性更新章节标题
+    - 脏页比例 > 65%：返回建议全量重新生成（不做任何更新）
+    - 新增文件无对应页面：忽略（下次全量重新生成时会覆盖）
+    - 已删除文件：从 relevant_files 中移除
+
+    返回:
+    {
+        "status": "updated" | "full_regen_suggested" | "no_wiki" | "no_changes",
+        "wiki_id": str | None,
+        "updated_pages": int,
+        "affected_ratio": float,
+        "suggestion_reason": str | None,
+    }
+    """
+    from app.models.wiki import Wiki, WikiSection, WikiPage
+    from app.models.repository import Repository
+    from sqlalchemy import select
+
+    # ── 加载现有 Wiki ────────────────────────────────────────
+    wiki_result = await db.execute(select(Wiki).where(Wiki.repo_id == repo_id))
+    wiki = wiki_result.scalar_one_or_none()
+
+    if not wiki:
+        # 尚无 Wiki，回退到全量生成
+        logger.info(f"[WikiIncrUpdate] repo_id={repo_id} 无现有 Wiki，回退全量生成")
+        wiki_result = await generate_wiki(
+            db, repo_id, llm_provider, llm_model, progress_callback, cancel_checker
+        )
+        return {"status": "no_wiki", "wiki_id": wiki_result["wiki_id"], "updated_pages": 0,
+                "skipped_pages": wiki_result.get("skipped_pages", 0),
+                "affected_ratio": 1.0, "suggestion_reason": None}
+
+    # ── 加载所有 Section + Page ──────────────────────────────
+    sections_result = await db.execute(
+        select(WikiSection).where(WikiSection.wiki_id == wiki.id)
+        .order_by(WikiSection.order_index)
+    )
+    sections = sections_result.scalars().all()
+
+    section_pages_map: Dict[str, List] = {}
+    all_pages = []
+    for section in sections:
+        pages_result = await db.execute(
+            select(WikiPage).where(WikiPage.section_id == section.id)
+            .order_by(WikiPage.order_index)
+        )
+        pages = pages_result.scalars().all()
+        section_pages_map[section.id] = pages
+        all_pages.extend(pages)
+
+    if not all_pages:
+        logger.info(f"[WikiIncrUpdate] repo_id={repo_id} Wiki 无页面，回退全量生成")
+        wiki_result = await generate_wiki(
+            db, repo_id, llm_provider, llm_model, progress_callback, cancel_checker
+        )
+        return {"status": "no_wiki", "wiki_id": wiki_result["wiki_id"], "updated_pages": 0,
+                "skipped_pages": wiki_result.get("skipped_pages", 0),
+                "affected_ratio": 1.0, "suggestion_reason": None}
+
+    # ── 路径规范化 ───────────────────────────────────────────
+    def _norm(p: str) -> str:
+        return p.replace("\\", "/").lstrip("/").lower()
+
+    changed_norm = {_norm(f) for f in changed_files if f}
+
+    if not changed_norm:
+        return {"status": "no_changes", "wiki_id": wiki.id, "updated_pages": 0,
+                "affected_ratio": 0.0, "suggestion_reason": None}
+
+    # ── 识别脏页 ─────────────────────────────────────────────
+    dirty_pages = []
+    clean_pages = []
+    page_section_map: Dict[str, WikiSection] = {}  # page.id -> section
+
+    for section in sections:
+        for page in section_pages_map.get(section.id, []):
+            page_section_map[page.id] = section
+            relevant_norm = {_norm(f) for f in (page.relevant_files or [])}
+            if relevant_norm & changed_norm:
+                dirty_pages.append(page)
+            else:
+                clean_pages.append(page)
+
+    affected_ratio = len(dirty_pages) / len(all_pages) if all_pages else 0.0
+    logger.info(
+        f"[WikiIncrUpdate] 脏页={len(dirty_pages)}/{len(all_pages)} "
+        f"(比例={affected_ratio:.1%}) repo_id={repo_id}"
+    )
+
+    # ── 阈值决策 ─────────────────────────────────────────────
+    FULL_REGEN_THRESHOLD = 0.65
+
+    if affected_ratio > FULL_REGEN_THRESHOLD:
+        reason = (
+            f"变更影响了 {len(dirty_pages)}/{len(all_pages)} 个页面（{affected_ratio:.0%}），"
+            "建议全量重新生成 Wiki 以确保内容完整性"
+        )
+        logger.info(f"[WikiIncrUpdate] {reason}")
+        return {
+            "status": "full_regen_suggested",
+            "wiki_id": wiki.id,
+            "updated_pages": 0,
+            "affected_ratio": affected_ratio,
+            "suggestion_reason": reason,
+        }
+
+    # ── 准备增量更新 ──────────────────────────────────────────
+    adapter = create_adapter(llm_provider)
+    model = llm_model or settings.DEFAULT_LLM_MODEL
+    language = settings.WIKI_LANGUAGE
+    collection = get_collection(repo_id)
+
+    repo_obj = await db.get(Repository, repo_id)
+    repo_name = repo_obj.name if repo_obj else repo_id
+
+    if progress_callback:
+        await progress_callback(5, f"增量更新：{len(dirty_pages)} 个页面受影响...")
+
+    # 删除文件的 relevant_files 清理：延迟到下次全量重新生成处理。
+    # 原因：changed_files 同时包含 A/M/D 三种类型，此处无法区分；
+    # 错误移除仍存在文件的路径会导致脏页判断失效。
+
+    # ── 并发更新脏页 ──────────────────────────────────────────
+    semaphore = asyncio.Semaphore(settings.WIKI_PAGE_CONCURRENCY)
+
+    async def _update_one(page: WikiPage) -> Tuple[WikiPage, Optional[str]]:
+        if cancel_checker:
+            await cancel_checker()
+        async with semaphore:
+            try:
+                section = page_section_map.get(page.id)
+                section_title = section.title if section else ""
+                code_context = await _retrieve_code_context(
+                    collection, page.relevant_files or [], page.title
+                )
+                new_content = await _generate_page_content(
+                    adapter, model,
+                    {
+                        "title": page.title,
+                        "importance": page.importance,
+                        "relevant_files": page.relevant_files or [],
+                        "order": page.order_index,
+                    },
+                    section_title, repo_name, code_context, language,
+                )
+                logger.info(f"[WikiIncrUpdate] 页面已更新: {page.title}")
+                return page, new_content
+            except Exception as e:
+                logger.error(f"[WikiIncrUpdate] 页面更新失败: {page.title} — {e}")
+                return page, None
+
+    tasks_list = [_update_one(p) for p in dirty_pages]
+    if progress_callback:
+        await progress_callback(15, f"并发更新 {len(dirty_pages)} 个受影响页面...")
+
+    results = await asyncio.gather(*tasks_list, return_exceptions=True)
+
+    # ── 写入 DB（串行） ───────────────────────────────────────
+    updated_count = 0
+    for result in results:
+        if isinstance(result, Exception):
+            continue
+        page, new_content = result
+        if new_content is not None:
+            page.content_md = new_content
+            updated_count += 1
+    # 先提交页面内容，确保 LLM 生成的内容不因后续章节标题评估失败而丢失
+    await db.commit()
+
+    # ── 弹性更新章节标题（显著变更时） ──────────────────────────
+    # IMPORTANT: _update_one 闭包中不访问 db，所有 DB 修改在 gather 完成后串行进行。
+    # 若将来 _generate_page_content / _retrieve_code_context 需要访问 db，
+    # 必须改为串行执行，因为 AsyncSession 不支持并发协程访问。
+    SECTION_TITLE_THRESHOLD = 0.80  # 章节内 80% 以上页面为脏页时，考虑更新章节标题
+    if affected_ratio > 0.20:  # 只有变更超过 20% 时才评估章节标题
+        for section in sections:
+            section_pages = section_pages_map.get(section.id, [])
+            if not section_pages:
+                continue
+            dirty_in_section = [p for p in section_pages if p in dirty_pages]
+            section_dirty_ratio = len(dirty_in_section) / len(section_pages)
+            if section_dirty_ratio >= SECTION_TITLE_THRESHOLD:
+                page_titles = [p.title for p in section_pages]
+                try:
+                    new_title = await _suggest_section_title(
+                        adapter, model, section.title, page_titles, repo_name
+                    )
+                    if new_title:
+                        logger.info(
+                            f"[WikiIncrUpdate] 章节标题更新: "
+                            f"'{section.title}' -> '{new_title}'"
+                        )
+                        section.title = new_title
+                except Exception as e:
+                    logger.warning(f"[WikiIncrUpdate] 章节标题评估失败: {e}")
+
+    await db.commit()
+
+    if progress_callback:
+        await progress_callback(95, f"增量更新完成：已更新 {updated_count} 个页面")
+
+    return {
+        "status": "updated",
+        "wiki_id": wiki.id,
+        "updated_pages": updated_count,
+        "affected_ratio": affected_ratio,
+        "suggestion_reason": None,
     }

--- a/app/tasks/incremental_sync.py
+++ b/app/tasks/incremental_sync.py
@@ -245,12 +245,15 @@ def _get_pending_commits_sync(repo_path: str, branch: str = "main") -> list:
     )
 
     # Step 2: git log（使用 ASCII RS \x1e 作分隔符，避免提交信息中的 | 破坏解析）
+    # encoding="utf-8" 是必须的：Git for Windows 输出 UTF-8，Windows 默认 ANSI 码页会导致解码失败
     result = subprocess.run(
         ["git", "log", f"HEAD..origin/{branch}",
          "--format=%H\x1e%s\x1e%an\x1e%ad", "--date=short"],
         cwd=repo_path,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=30,
     )
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -400,7 +400,7 @@ es.onmessage = (event) => {
 
 ### POST /api/wiki/{repo_id}/regenerate — 重新生成 Wiki
 
-触发指定仓库的 Wiki 重新生成任务，返回 task_id 供 SSE 跟踪进度。
+触发指定仓库的 Wiki 重新生成任务，返回 task_id 供 SSE 跟踪进度。支持全量重新生成（重建大纲和所有页面）或选择性重新生成（仅更新指定页面的 `content_md`，不改动大纲和其他页面）。
 
 **路径参数**:
 
@@ -422,7 +422,7 @@ es.onmessage = (event) => {
 |------|------|------|------|
 | `llm_provider` | string | 否 | LLM 供应商，不填则使用环境变量默认值 |
 | `llm_model` | string | 否 | 模型名称 |
-| `pages` | array | 否 | 仅重新生成指定页面 ID 列表（预留，当前全量重生成） |
+| `pages` | array | 否 | 指定页面 ID 列表。**有值**时仅重新生成这些页面（选择性模式）；**不传或为 null** 时全量重新生成整个 Wiki |
 
 **成功响应 (201)**:
 

--- a/frontend/src/api/repositories.ts
+++ b/frontend/src/api/repositories.ts
@@ -125,3 +125,25 @@ export async function getFileContent(
   )
   return response.data
 }
+
+export interface CommitInfo {
+  hash: string
+  short_hash: string
+  message: string
+  author: string
+  date: string
+}
+
+export interface PendingCommitsResponse {
+  repo_id: string
+  branch: string
+  count: number
+  commits: CommitInfo[]
+}
+
+export async function getPendingCommits(repoId: string): Promise<PendingCommitsResponse> {
+  const response = await apiClient.get<PendingCommitsResponse>(
+    `/repositories/${repoId}/pending-commits`
+  )
+  return response.data
+}

--- a/frontend/src/components/WikiRegenerateDialog.vue
+++ b/frontend/src/components/WikiRegenerateDialog.vue
@@ -1,0 +1,528 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type { WikiResponse } from '@/api/wiki'
+
+const props = defineProps<{
+  wiki: WikiResponse | null
+  visible: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:visible': [value: boolean]
+  confirm: [payload: { mode: 'full' | 'partial'; pageIds: string[] }]
+  cancel: []
+}>()
+
+function hasEmptyPages(): boolean {
+  if (!props.wiki) return false
+  for (const section of props.wiki.sections) {
+    for (const page of section.pages) {
+      if (!page.content_md || page.content_md.trim() === '') return true
+    }
+  }
+  return false
+}
+
+const mode = ref<'full' | 'partial'>(hasEmptyPages() ? 'partial' : 'full')
+const selectedPageIds = ref<Set<string>>(new Set())
+
+function isPageEmpty(contentMd: string): boolean {
+  return !contentMd || contentMd.trim() === ''
+}
+
+function initSelection() {
+  const initial = new Set<string>()
+  if (!props.wiki) return initial
+  for (const section of props.wiki.sections) {
+    for (const page of section.pages) {
+      if (isPageEmpty(page.content_md)) {
+        initial.add(page.id)
+      }
+    }
+  }
+  return initial
+}
+
+watch(
+  () => props.visible,
+  (open) => {
+    if (open) {
+      mode.value = hasEmptyPages() ? 'partial' : 'full'
+      selectedPageIds.value = initSelection()
+    }
+  },
+  { immediate: true }
+)
+
+function getSectionState(sectionId: string): 'all' | 'some' | 'none' {
+  if (!props.wiki) return 'none'
+  const section = props.wiki.sections.find(s => s.id === sectionId)
+  if (!section || section.pages.length === 0) return 'none'
+  const checkedCount = section.pages.filter(p => selectedPageIds.value.has(p.id)).length
+  if (checkedCount === section.pages.length) return 'all'
+  if (checkedCount > 0) return 'some'
+  return 'none'
+}
+
+function toggleSection(sectionId: string) {
+  if (!props.wiki) return
+  const section = props.wiki.sections.find(s => s.id === sectionId)
+  if (!section) return
+  const state = getSectionState(sectionId)
+  const next = new Set(selectedPageIds.value)
+  if (state === 'all') {
+    for (const page of section.pages) next.delete(page.id)
+  } else {
+    for (const page of section.pages) next.add(page.id)
+  }
+  selectedPageIds.value = next
+}
+
+function togglePage(pageId: string) {
+  const next = new Set(selectedPageIds.value)
+  if (next.has(pageId)) {
+    next.delete(pageId)
+  } else {
+    next.add(pageId)
+  }
+  selectedPageIds.value = next
+}
+
+const canConfirm = computed(() => {
+  if (mode.value === 'full') return true
+  return selectedPageIds.value.size > 0
+})
+
+function handleConfirm() {
+  emit('confirm', {
+    mode: mode.value,
+    pageIds: mode.value === 'partial' ? [...selectedPageIds.value] : [],
+  })
+}
+
+function handleClose() {
+  emit('update:visible', false)
+  emit('cancel')
+}
+
+function handleBackdrop() {
+  handleClose()
+}
+
+function setSectionIndeterminate(el: HTMLInputElement | null, sectionId: string) {
+  if (!el) return
+  const state = getSectionState(sectionId)
+  el.indeterminate = state === 'some'
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="regen-fade">
+      <div v-if="visible" class="regen-overlay" @click.self="handleBackdrop">
+        <div class="regen-modal" role="dialog" aria-modal="true" aria-label="重新生成 Wiki">
+          <!-- Header -->
+          <div class="regen-modal__header">
+            <span class="regen-modal__title">重新生成 Wiki</span>
+            <button class="regen-modal__close" @click="handleClose" aria-label="关闭">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18"/>
+                <line x1="6" y1="6" x2="18" y2="18"/>
+              </svg>
+            </button>
+          </div>
+
+          <!-- Body -->
+          <div class="regen-modal__body">
+            <!-- Mode selection -->
+            <div class="regen-modes">
+              <label class="regen-mode" :class="{ 'regen-mode--active': mode === 'full' }">
+                <input
+                  type="radio"
+                  name="regen-mode"
+                  value="full"
+                  v-model="mode"
+                  class="regen-mode__radio"
+                />
+                <div class="regen-mode__content">
+                  <span class="regen-mode__label">全量重新生成</span>
+                  <span class="regen-mode__desc">重新生成所有页面和大纲</span>
+                </div>
+              </label>
+              <label class="regen-mode" :class="{ 'regen-mode--active': mode === 'partial' }">
+                <input
+                  type="radio"
+                  name="regen-mode"
+                  value="partial"
+                  v-model="mode"
+                  class="regen-mode__radio"
+                />
+                <div class="regen-mode__content">
+                  <span class="regen-mode__label">选择性重新生成</span>
+                  <span class="regen-mode__desc">仅重新生成选中的页面</span>
+                </div>
+              </label>
+            </div>
+
+            <!-- Page tree (partial mode only) -->
+            <div v-if="mode === 'partial' && wiki" class="regen-tree">
+              <div
+                v-for="section in wiki.sections"
+                :key="section.id"
+                class="regen-section"
+              >
+                <!-- Section row -->
+                <label class="regen-row regen-row--section">
+                  <input
+                    type="checkbox"
+                    :ref="(el) => setSectionIndeterminate(el as HTMLInputElement | null, section.id)"
+                    :checked="getSectionState(section.id) === 'all'"
+                    @change="toggleSection(section.id)"
+                    class="regen-checkbox"
+                  />
+                  <span class="regen-row__label regen-row__label--section">{{ section.title }}</span>
+                </label>
+
+                <!-- Page rows -->
+                <label
+                  v-for="page in section.pages"
+                  :key="page.id"
+                  class="regen-row regen-row--page"
+                >
+                  <input
+                    type="checkbox"
+                    :checked="selectedPageIds.has(page.id)"
+                    @change="togglePage(page.id)"
+                    class="regen-checkbox"
+                  />
+                  <span class="regen-row__label">{{ page.title }}</span>
+                  <span
+                    v-if="isPageEmpty(page.content_md)"
+                    class="regen-badge regen-badge--empty"
+                    title="该页面内容为空"
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                      <line x1="12" y1="9" x2="12" y2="13"/>
+                      <line x1="12" y1="17" x2="12.01" y2="17"/>
+                    </svg>
+                    内容为空
+                  </span>
+                </label>
+              </div>
+
+              <!-- Empty selection hint -->
+              <div v-if="selectedPageIds.size === 0" class="regen-hint">
+                请至少选择一个页面
+              </div>
+            </div>
+          </div>
+
+          <!-- Footer -->
+          <div class="regen-modal__footer">
+            <button class="btn btn-secondary" @click="handleClose">取消</button>
+            <button
+              class="btn btn-primary"
+              @click="handleConfirm"
+              :disabled="!canConfirm"
+            >
+              开始生成
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.regen-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.regen-modal {
+  width: 100%;
+  max-width: 480px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.18), 0 8px 24px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+[data-theme="dark"] .regen-modal {
+  background: #161616;
+  border-color: #2a2a2a;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55), 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+/* Header */
+.regen-modal__header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg-primary);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 18px 14px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .regen-modal__header {
+  background: #161616;
+}
+
+.regen-modal__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.regen-modal__close {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  color: var(--text-muted);
+  transition: background 0.15s, color 0.15s;
+}
+
+.regen-modal__close svg {
+  width: 15px;
+  height: 15px;
+}
+
+.regen-modal__close:hover {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+/* Body */
+.regen-modal__body {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Mode options */
+.regen-modes {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.regen-mode {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.regen-mode:hover {
+  background: var(--bg-hover);
+}
+
+.regen-mode--active {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light, rgba(99, 102, 241, 0.06));
+}
+
+.regen-mode__radio {
+  margin-top: 2px;
+  flex-shrink: 0;
+  accent-color: var(--color-primary);
+}
+
+.regen-mode__content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.regen-mode__label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.regen-mode__desc {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+/* Page tree */
+.regen-tree {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+}
+
+.regen-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.regen-section + .regen-section {
+  border-top: 1px solid var(--border-color);
+}
+
+.regen-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.regen-row:hover {
+  background: var(--bg-hover);
+}
+
+.regen-row--section {
+  background: var(--bg-secondary);
+  padding: 8px 12px;
+}
+
+.regen-row--page {
+  padding-left: 28px;
+}
+
+.regen-row--page + .regen-row--page {
+  border-top: 1px solid var(--border-color);
+}
+
+.regen-checkbox {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+  accent-color: var(--color-primary);
+}
+
+.regen-row__label {
+  font-size: 13px;
+  color: var(--text-secondary);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.regen-row__label--section {
+  font-weight: 500;
+  color: var(--text-primary);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Empty content badge */
+.regen-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 6px;
+  border-radius: 4px;
+  line-height: 1.4;
+}
+
+.regen-badge--empty {
+  color: #b45309;
+  background: rgba(217, 119, 6, 0.1);
+  border: 1px solid rgba(217, 119, 6, 0.25);
+}
+
+[data-theme="dark"] .regen-badge--empty {
+  color: #fbbf24;
+  background: rgba(251, 191, 36, 0.1);
+  border-color: rgba(251, 191, 36, 0.2);
+}
+
+.regen-badge svg {
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+}
+
+/* Empty selection hint */
+.regen-hint {
+  padding: 10px 14px;
+  font-size: 12px;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border-color);
+  text-align: center;
+}
+
+/* Footer */
+.regen-modal__footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  background: var(--bg-primary);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .regen-modal__footer {
+  background: #161616;
+}
+
+/* Transition */
+.regen-fade-enter-active,
+.regen-fade-leave-active {
+  transition: opacity 0.18s ease;
+}
+
+.regen-fade-enter-active .regen-modal,
+.regen-fade-leave-active .regen-modal {
+  transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+.regen-fade-enter-from,
+.regen-fade-leave-to {
+  opacity: 0;
+}
+
+.regen-fade-enter-from .regen-modal,
+.regen-fade-leave-to .regen-modal {
+  transform: translateY(-6px);
+  opacity: 0;
+}
+</style>

--- a/frontend/src/views/RepoListView.vue
+++ b/frontend/src/views/RepoListView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { getRepositories, deleteRepository, reprocessRepository, syncRepository, abortRepository } from '@/api/repositories'
+import { getRepositories, deleteRepository, reprocessRepository, syncRepository, abortRepository, getPendingCommits, type CommitInfo } from '@/api/repositories'
 import { regenerateWiki } from '@/api/wiki'
 import { useRepoStore } from '@/stores/repo'
 import { useTaskStore } from '@/stores/task'
@@ -23,6 +23,11 @@ const showSyncModal = ref(false)
 const syncLlmProvider = ref('')
 const syncLlmModel = ref('')
 const showSyncAdvanced = ref(false)
+const pendingCommits = ref<CommitInfo[]>([])
+const pendingCommitsLoading = ref(false)
+const pendingCommitsError = ref('')
+const showPendingCommits = ref(false)
+const pendingCommitsBranch = ref('')
 
 const filteredRepos = computed(() => {
   if (!filterStatus.value) return repoStore.repos
@@ -140,6 +145,28 @@ async function handleSync(repo: RepositoryItem) {
   syncLlmProvider.value = ''
   syncLlmModel.value = ''
   showSyncAdvanced.value = false
+  // 重置提交列表状态
+  pendingCommits.value = []
+  pendingCommitsLoading.value = false
+  pendingCommitsError.value = ''
+  showPendingCommits.value = false
+  pendingCommitsBranch.value = ''
+}
+
+async function loadPendingCommits() {
+  if (!syncTarget.value) return
+  pendingCommitsLoading.value = true
+  pendingCommitsError.value = ''
+  showPendingCommits.value = true
+  try {
+    const result = await getPendingCommits(syncTarget.value.id)
+    pendingCommits.value = result.commits
+    pendingCommitsBranch.value = result.branch
+  } catch {
+    pendingCommitsError.value = '获取提交列表失败，请检查网络连接'
+  } finally {
+    pendingCommitsLoading.value = false
+  }
 }
 
 async function confirmSync() {
@@ -407,14 +434,61 @@ onMounted(loadRepos)
 
     <!-- 增量同步弹窗 -->
     <div v-if="showSyncModal" class="modal-overlay" @click.self="showSyncModal = false">
-      <div class="modal card">
+      <div class="modal card sync-modal">
         <h3>增量更新仓库</h3>
         <p>
           将对仓库 <strong>{{ syncTarget?.name }}</strong> 执行增量同步：
-          拉取最新代码、仅重新处理变更文件并重新生成 Wiki。
+          拉取最新代码、仅重新处理变更文件并更新 Wiki。
           <br><br>
           <strong>同步期间将暂时无法查看 Wiki。</strong>
         </p>
+
+        <!-- 待同步提交查看器 -->
+        <div class="commits-section">
+          <button
+            class="advanced-toggle"
+            :disabled="pendingCommitsLoading"
+            @click="showPendingCommits ? (showPendingCommits = false) : loadPendingCommits()"
+          >
+            <svg
+              class="advanced-toggle__chevron"
+              :class="{ 'advanced-toggle__chevron--open': showPendingCommits }"
+              viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2"
+            >
+              <path d="M4 6l4 4 4-4" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span v-if="pendingCommitsLoading">正在获取提交列表...</span>
+            <span v-else-if="showPendingCommits && pendingCommits.length > 0">
+              隐藏提交列表（{{ pendingCommits.length }} 个新提交，分支：{{ pendingCommitsBranch }}）
+            </span>
+            <span v-else-if="showPendingCommits && pendingCommits.length === 0">
+              隐藏提交列表
+            </span>
+            <span v-else>查看待同步提交</span>
+          </button>
+
+          <div v-if="showPendingCommits" class="commits-panel">
+            <div v-if="pendingCommitsLoading" class="commits-loading">
+              <span class="spinner spinner--sm" />
+              <span>正在 git fetch...</span>
+            </div>
+            <div v-else-if="pendingCommitsError" class="commits-error">{{ pendingCommitsError }}</div>
+            <div v-else-if="pendingCommits.length === 0" class="commits-empty">
+              当前分支已是最新，无待同步提交。
+            </div>
+            <div v-else class="commits-list">
+              <div
+                v-for="commit in pendingCommits"
+                :key="commit.hash"
+                class="commit-item"
+              >
+                <code class="commit-hash">{{ commit.short_hash }}</code>
+                <span class="commit-message">{{ commit.message }}</span>
+                <span class="commit-meta">{{ commit.author }} · {{ commit.date }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
 
         <!-- LLM 高级选项 -->
         <button class="advanced-toggle" @click="showSyncAdvanced = !showSyncAdvanced">
@@ -783,4 +857,75 @@ onMounted(loadRepos)
 }
 .form-input:focus { border-color: var(--color-primary); }
 .form-select { cursor: pointer; }
+
+/* ── Sync modal ───────────────────────────────────── */
+.sync-modal {
+  max-width: 520px;
+}
+
+.commits-section {
+  margin-top: 4px;
+}
+
+.commits-panel {
+  margin-top: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.commits-loading,
+.commits-error,
+.commits-empty {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.commits-error { color: #ef4444; }
+
+.commits-list {
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.commit-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border-color);
+  font-size: var(--font-size-xs);
+}
+.commit-item:last-child { border-bottom: none; }
+
+.commit-hash {
+  font-family: var(--font-mono);
+  color: var(--color-primary);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.commit-message {
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.commit-meta {
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.spinner--sm {
+  width: 14px;
+  height: 14px;
+  border-width: 2px;
+}
 </style>

--- a/frontend/src/views/RepoListView.vue
+++ b/frontend/src/views/RepoListView.vue
@@ -441,6 +441,8 @@ onMounted(loadRepos)
           拉取最新代码、仅重新处理变更文件并更新 Wiki。
           <br><br>
           <strong>同步期间将暂时无法查看 Wiki。</strong>
+          <br>
+          <strong>若当前仓库更新过多，建议点击重新生成按钮进行全量更新，增量更新只适合大纲改动不大的场景</strong>
         </p>
 
         <!-- 待同步提交查看器 -->

--- a/frontend/src/views/RepoListView.vue
+++ b/frontend/src/views/RepoListView.vue
@@ -186,7 +186,10 @@ async function confirmSync() {
 
 function formatDate(dateStr: string | null) {
   if (!dateStr) return '从未同步'
-  return new Date(dateStr).toLocaleString('zh-CN', {
+  // 后端返回 naive datetime（无时区后缀），需补 Z 告知 JS 这是 UTC，
+  // 否则 JS 会将其当本地时间解析，导致 UTC+8 下显示时间偏早 8 小时
+  const normalized = /Z|[+-]\d{2}:\d{2}$/.test(dateStr) ? dateStr : dateStr + 'Z'
+  return new Date(normalized).toLocaleString('zh-CN', {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',


### PR DESCRIPTION
## 概述

  本 PR 包含三个独立功能点及若干 bug 修复，主要围绕 Wiki 生成流程的精细化控制和可观测性提升。

  ---

  ## 新功能

  ### 1. 真正的增量 Wiki 更新
  - `wiki_generator` 新增 `update_wiki_incrementally()`，通过 `WikiPage.relevant_files` 与变更文件集合取交集识别"脏页"，仅重新生成受影响页面
  - 三档策略：脏页 ≤65% 仅更新脏页；>65% 建议全量重生成；无现有 Wiki 回退全量生成
  - 章节标题弹性更新：章节内 ≥80% 页面为脏页时，LLM 评估是否需更新章节标题
  - `INCREMENTAL_SYNC` 阶段 4 改为调用 `update_wiki_incrementally()`，完成事件携带 `wiki_regen_suggestion` 提示前端

  ### 2. Git 待同步提交查看器
  - 新增 `GET /api/repositories/{repo_id}/pending-commits` 端点，返回结构化提交列表（hash/消息/作者/日期）
  - 前端 sync 弹窗新增「查看待同步提交」折叠面板

  ### 3. 选择性重新生成 Wiki 页面
  - `POST /api/wiki/{repo_id}/regenerate` 的 `pages` 字段由预留变为实际可用：传入页面 ID 列表时仅更新这些页面的 `content_md`，不重建大纲和其他页面
  - 后端新增 `regenerate_specific_pages()`，复用三智能体生成逻辑
  - 前端「重新生成」按钮改为弹出选择对话框，支持全量/选择性两种模式；空内容页面自动预选并标记警告

  ---

  ## Bug 修复

  - **LLM 适配器**：补充 `APIConnectionError` / `InternalServerError` 重试类型，减少因 API 服务端抖动导致的任务整体失败
  - **pending-commits**：修复 Windows 下 `git log` 中文输出编码错误
  - **incremental_sync**：`sync_stats` 在异常路径下未定义导致 `NameError`；`git fetch/merge` 失败时静默忽略返回码；`changed_paths` 变量遮蔽；`git log`
   分隔符含 `|` 时字段错位（改用 `\x1e`）
  - **wiki_generator**：删除文件处理块为无效死代码；页面内容 flush 后章节标题异常导致内容回滚

  ---

  ## 涉及文件

  `app/services/wiki_generator.py` · `app/tasks/process_repo.py` · `app/tasks/incremental_sync.py` · `app/api/wiki.py` · `app/api/repositories.py` ·
  `app/services/llm/` · `frontend/src/components/WikiRegenerateDialog.vue` · `frontend/src/views/WikiView.vue` · `doc/API.md` · `doc/PIPELINE.md`