### PR TITLE
feat: 访问鉴权、LLM 稳定性增强与多项前端体验优化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,13 @@ WIKI_LANGUAGE=Chinese
 DEBUG=false
 LOG_LEVEL=INFO
 REPOS_BASE_DIR=./repos
+
+# === 文件日志 ===
+# 开启后将日志同步写入本地磁盘（默认关闭）
+ENABLE_FILE_LOGGING=false
+# 日志目录（相对于项目根目录）
+LOG_DIR=logs
+# 单个日志文件最大体积（MB），超出后自动轮转（.1/.2/...）
+LOG_MAX_SIZE_MB=50
+# 保留的历史日志份数（超出后删除最旧的）
+LOG_BACKUP_COUNT=5

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,12 @@ MAX_CONCURRENT_LLM_CALLS=10
 # === MCP Server ===
 MCP_AUTH_TOKEN=your-secure-random-token-here
 
+# === 访问鉴权 ===
+# 部署到公网时建议开启，防止未授权恶意提交
+# AUTH_ENABLED=false           # 设为 true 开启登录验证
+# AUTH_PASSWORD=your-password  # 登录口令（自定义任意字符串）
+# AUTH_SESSION_EXPIRE_HOURS=168  # 登录有效期（小时），默认 7 天
+
 # === Wiki 生成语言 ===
 # 生成的所有 Wiki 内容强制使用该语言，留空或不设置则默认为 Chinese
 # 可选值：Chinese / English / Japanese / French / German / 其他自然语言名称

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,0 +1,50 @@
+import logging
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from app.config import settings
+from app.core.auth import create_session_token, delete_session_token
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+class LoginRequest(BaseModel):
+    password: str
+
+
+@router.get("/status", summary="获取鉴权状态")
+async def get_auth_status():
+    """返回鉴权是否启用，前端据此决定是否跳转登录页。始终公开访问。"""
+    return {"enabled": settings.AUTH_ENABLED}
+
+
+@router.post("/login", summary="登录")
+async def login(body: LoginRequest):
+    """验证口令，成功后颁发会话 token（存储在 Redis，有效期由 AUTH_SESSION_EXPIRE_HOURS 控制）。"""
+    if not settings.AUTH_ENABLED:
+        return {"token": None, "message": "鉴权未启用"}
+
+    if not settings.AUTH_PASSWORD:
+        raise HTTPException(
+            status_code=503,
+            detail="AUTH_PASSWORD 未配置，请在 .env 中设置登录口令",
+        )
+
+    if body.password != settings.AUTH_PASSWORD:
+        raise HTTPException(status_code=401, detail="口令错误")
+
+    token = await create_session_token()
+    logger.info("[Auth] 登录成功，颁发新会话 token")
+    return {"token": token}
+
+
+@router.post("/logout", summary="登出")
+async def logout(request: Request):
+    """使当前会话 token 立即失效。"""
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:].strip()
+        await delete_session_token(token)
+    return {"message": "已登出"}

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -35,6 +35,8 @@ def setup_worker_logging(**kwargs):
         level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
         format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
     )
+    from app.core.logging_setup import setup_file_logging
+    setup_file_logging(settings)
     logger = logging.getLogger("celery.worker")
     logger.info(f"[Worker] 日志级别: {settings.LOG_LEVEL.upper()}, Broker: {settings.REDIS_URL}")
 

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -36,7 +36,7 @@ def setup_worker_logging(**kwargs):
         format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
     )
     from app.core.logging_setup import setup_file_logging
-    setup_file_logging(settings)
+    setup_file_logging(settings, process_name="worker")
     logger = logging.getLogger("celery.worker")
     logger.info(f"[Worker] 日志级别: {settings.LOG_LEVEL.upper()}, Broker: {settings.REDIS_URL}")
 

--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,12 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     REPOS_BASE_DIR: str = "./repos"
 
+    # 文件日志
+    ENABLE_FILE_LOGGING: bool = False        # 是否将日志写入本地文件
+    LOG_DIR: str = "logs"                    # 日志目录
+    LOG_MAX_SIZE_MB: int = 50               # 单个日志文件最大体积（MB），超出后轮转
+    LOG_BACKUP_COUNT: int = 5               # 保留的历史日志份数（.1/.2/...）
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,11 @@ class Settings(BaseSettings):
     # MCP
     MCP_AUTH_TOKEN: Optional[str] = None
 
+    # 访问鉴权（部署到公网时开启，防止未授权提交）
+    AUTH_ENABLED: bool = False
+    AUTH_PASSWORD: Optional[str] = None
+    AUTH_SESSION_EXPIRE_HOURS: int = 168  # 默认 7 天
+
     # Wiki 生成语言（生成的所有 Wiki 内容强制使用该语言）
     # 示例：Chinese / English / Japanese / French / German
     WIKI_LANGUAGE: str = "Chinese"

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,0 +1,66 @@
+import secrets
+import logging
+from fastapi import HTTPException, Request
+
+logger = logging.getLogger(__name__)
+
+AUTH_TOKEN_PREFIX = "auth:session:"
+
+
+async def create_session_token() -> str:
+    """生成会话 token 并存入 Redis，返回 token 字符串。"""
+    from app.core.redis_client import get_redis
+    from app.config import settings
+
+    token = secrets.token_urlsafe(32)
+    redis = await get_redis()
+    expire_seconds = settings.AUTH_SESSION_EXPIRE_HOURS * 3600
+    await redis.setex(f"{AUTH_TOKEN_PREFIX}{token}", expire_seconds, "1")
+    return token
+
+
+async def delete_session_token(token: str) -> None:
+    """删除会话 token（登出）。"""
+    from app.core.redis_client import get_redis
+
+    redis = await get_redis()
+    await redis.delete(f"{AUTH_TOKEN_PREFIX}{token}")
+
+
+async def verify_session_token(token: str) -> bool:
+    """检查 token 在 Redis 中是否存在且有效。"""
+    from app.core.redis_client import get_redis
+
+    redis = await get_redis()
+    return bool(await redis.exists(f"{AUTH_TOKEN_PREFIX}{token}"))
+
+
+async def require_auth(request: Request) -> None:
+    """FastAPI 依赖项：验证请求携带有效会话 token。
+
+    AUTH_ENABLED=False 时直接放行，无任何开销。
+    Token 来源（按优先级）：
+      1. Authorization: Bearer <token> 请求头（普通 API 请求）
+      2. ?token=<token> 查询参数（EventSource SSE，不支持自定义 header）
+    """
+    from app.config import settings
+
+    if not settings.AUTH_ENABLED:
+        return
+
+    token: str | None = None
+
+    # 优先从 Bearer header 获取
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:].strip()
+
+    # SSE 降级：从 query param 获取
+    if not token:
+        token = request.query_params.get("token")
+
+    if not token:
+        raise HTTPException(status_code=401, detail="未授权，请登录")
+
+    if not await verify_session_token(token):
+        raise HTTPException(status_code=401, detail="登录已过期，请重新登录")

--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -1,0 +1,66 @@
+"""
+文件日志配置模块。
+
+通过 .env 中的 ENABLE_FILE_LOGGING=true 开启，产生两类日志文件：
+  logs/app.log          — 调试日志，镜像所有控制台输出（FastAPI + Celery）
+  logs/llm_failures.log — LLM 失败详情，含完整 prompt 和响应，便于调试
+
+日志轮转：单文件达到 LOG_MAX_SIZE_MB 上限后自动轮转，保留 LOG_BACKUP_COUNT 份。
+"""
+import logging
+import logging.handlers
+from pathlib import Path
+
+_file_logging_initialized = False
+
+
+def setup_file_logging(settings) -> None:
+    """
+    初始化文件日志。幂等：重复调用无副作用。
+
+    在 FastAPI lifespan 启动前和 Celery worker_init 信号中各调用一次。
+    """
+    global _file_logging_initialized
+    if _file_logging_initialized or not settings.ENABLE_FILE_LOGGING:
+        return
+    _file_logging_initialized = True
+
+    log_dir = Path(settings.LOG_DIR)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    max_bytes = settings.LOG_MAX_SIZE_MB * 1024 * 1024
+    fmt = logging.Formatter(
+        "%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    # ── 1. 调试日志：镜像所有控制台输出 ─────────────────────────────────────
+    app_handler = logging.handlers.RotatingFileHandler(
+        log_dir / "app.log",
+        maxBytes=max_bytes,
+        backupCount=settings.LOG_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    app_handler.setLevel(logging.DEBUG)
+    app_handler.setFormatter(fmt)
+    logging.getLogger().addHandler(app_handler)
+
+    # ── 2. LLM 失败日志：独立文件，含完整 prompt + response ─────────────────
+    llm_handler = logging.handlers.RotatingFileHandler(
+        log_dir / "llm_failures.log",
+        maxBytes=max_bytes * 2,   # prompt 内容较大，分配双倍空间
+        backupCount=settings.LOG_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    llm_handler.setLevel(logging.DEBUG)
+    llm_handler.setFormatter(fmt)
+
+    llm_logger = logging.getLogger("llm.failures")
+    llm_logger.addHandler(llm_handler)
+    llm_logger.setLevel(logging.DEBUG)
+    llm_logger.propagate = False  # 不向 root 传播，避免 prompt 明文出现在控制台
+
+    logging.getLogger(__name__).info(
+        f"[Logging] 文件日志已启用 → {log_dir.resolve()} "
+        f"（单文件上限 {settings.LOG_MAX_SIZE_MB} MB，保留 {settings.LOG_BACKUP_COUNT} 份）"
+    )

--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -1,8 +1,9 @@
 """
 文件日志配置模块。
 
-通过 .env 中的 ENABLE_FILE_LOGGING=true 开启，产生两类日志文件：
-  logs/app.log          — 调试日志，镜像所有控制台输出（FastAPI + Celery）
+通过 .env 中的 ENABLE_FILE_LOGGING=true 开启，产生三类日志文件：
+  logs/api.log          — FastAPI 进程日志
+  logs/worker.log       — Celery Worker 进程日志
   logs/llm_failures.log — LLM 失败详情，含完整 prompt 和响应，便于调试
 
 日志轮转：单文件达到 LOG_MAX_SIZE_MB 上限后自动轮转，保留 LOG_BACKUP_COUNT 份。
@@ -14,9 +15,13 @@ from pathlib import Path
 _file_logging_initialized = False
 
 
-def setup_file_logging(settings) -> None:
+def setup_file_logging(settings, process_name: str = "app") -> None:
     """
     初始化文件日志。幂等：重复调用无副作用。
+
+    process_name 决定进程日志文件名：
+      "api"    → logs/api.log    （由 main.py 传入）
+      "worker" → logs/worker.log  （由 celery_app.py 传入）
 
     在 FastAPI lifespan 启动前和 Celery worker_init 信号中各调用一次。
     """
@@ -34,16 +39,16 @@ def setup_file_logging(settings) -> None:
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    # ── 1. 调试日志：镜像所有控制台输出 ─────────────────────────────────────
-    app_handler = logging.handlers.RotatingFileHandler(
-        log_dir / "app.log",
+    # ── 1. 进程日志：按进程类型分文件 ────────────────────────────────────────
+    process_handler = logging.handlers.RotatingFileHandler(
+        log_dir / f"{process_name}.log",
         maxBytes=max_bytes,
         backupCount=settings.LOG_BACKUP_COUNT,
         encoding="utf-8",
     )
-    app_handler.setLevel(logging.DEBUG)
-    app_handler.setFormatter(fmt)
-    logging.getLogger().addHandler(app_handler)
+    process_handler.setLevel(logging.DEBUG)
+    process_handler.setFormatter(fmt)
+    logging.getLogger().addHandler(process_handler)
 
     # ── 2. LLM 失败日志：独立文件，含完整 prompt + response ─────────────────
     llm_handler = logging.handlers.RotatingFileHandler(
@@ -61,6 +66,6 @@ def setup_file_logging(settings) -> None:
     llm_logger.propagate = False  # 不向 root 传播，避免 prompt 明文出现在控制台
 
     logging.getLogger(__name__).info(
-        f"[Logging] 文件日志已启用 → {log_dir.resolve()} "
+        f"[Logging] 文件日志已启用 → {log_dir.resolve()}/{process_name}.log "
         f"（单文件上限 {settings.LOG_MAX_SIZE_MB} MB，保留 {settings.LOG_BACKUP_COUNT} 份）"
     )

--- a/app/main.py
+++ b/app/main.py
@@ -5,12 +5,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.database import init_db, engine
 from app.core.redis_client import init_redis, close_redis
 from app.config import settings
+from app.core.logging_setup import setup_file_logging
 
 # 配置日志
 logging.basicConfig(
     level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
+setup_file_logging(settings)
 logger = logging.getLogger(__name__)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,7 @@ logging.basicConfig(
     level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
-setup_file_logging(settings)
+setup_file_logging(settings, process_name="api")
 logger = logging.getLogger(__name__)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 import logging
 from contextlib import asynccontextmanager
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from app.database import init_db, engine
 from app.core.redis_client import init_redis, close_redis
@@ -56,17 +56,23 @@ app.add_middleware(
 from app.models.repo_index import RepoIndex  # noqa: F401
 
 # 注册路由
+from app.api.auth import router as auth_router
 from app.api.repositories import router as repositories_router
 from app.api.tasks import router as tasks_router
 from app.api.wiki import router as wiki_router
 from app.api.chat import router as chat_router
 from app.api.system import router as system_router
+from app.core.auth import require_auth
 
-app.include_router(repositories_router)
-app.include_router(tasks_router)
-app.include_router(wiki_router)
-app.include_router(chat_router)
-app.include_router(system_router)
+# auth 路由公开访问（登录/登出/状态查询不需要鉴权）
+app.include_router(auth_router)
+
+# 其余路由受 require_auth 保护（AUTH_ENABLED=False 时依赖项直接放行）
+app.include_router(repositories_router, dependencies=[Depends(require_auth)])
+app.include_router(tasks_router, dependencies=[Depends(require_auth)])
+app.include_router(wiki_router, dependencies=[Depends(require_auth)])
+app.include_router(chat_router, dependencies=[Depends(require_auth)])
+app.include_router(system_router, dependencies=[Depends(require_auth)])
 
 
 @app.get("/health", tags=["health"])

--- a/app/services/llm/adapter.py
+++ b/app/services/llm/adapter.py
@@ -75,3 +75,12 @@ class BaseLLMAdapter(ABC):
         async with self._get_semaphore():
             async for chunk in self.stream(messages, model, temperature, max_tokens):
                 yield chunk
+
+    async def aclose(self) -> None:
+        """释放底层 HTTP 客户端资源，子类按需覆写"""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        await self.aclose()

--- a/app/services/llm/adapter.py
+++ b/app/services/llm/adapter.py
@@ -6,9 +6,89 @@ from typing import AsyncIterator, List, Optional
 from app.schemas.llm import LLMMessage, LLMResponse
 
 logger = logging.getLogger(__name__)
+_llm_failure_logger = logging.getLogger("llm.failures")
 
 # 单次 LLM API 调用超时（秒），超时后触发重试
 LLM_CALL_TIMEOUT = 240  # 4 分钟
+
+
+def _make_before_sleep_log(adapter_name: str):
+    """
+    生成 tenacity before_sleep 回调。
+    429 / 限流重试时：
+      - 向终端输出 WARNING 级日志，包含等待秒数和错误详情
+      - 同步写入 llm_failures.log 文件（ENABLE_FILE_LOGGING=true 时生效）
+    其他错误（超时、连接失败等）：仅输出 WARNING，不写文件日志。
+    """
+    def _before_sleep(retry_state) -> None:
+        exc = retry_state.outcome.exception() if retry_state.outcome else None
+        wait_secs = retry_state.upcoming_sleep
+        attempt = retry_state.attempt_number
+
+        error_type = type(exc).__name__ if exc else "Unknown"
+        error_detail = str(exc)[:300] if exc else ""
+        status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        is_rate_limit = status_code == 429 or "RateLimitError" in error_type
+
+        if is_rate_limit:
+            console_msg = (
+                f"[{adapter_name}] API 频率限制 (429) — "
+                f"第 {attempt} 次重试，暂停等待 {wait_secs:.0f}s 后继续\n"
+                f"  错误详情: {error_detail}"
+            )
+            logger.warning(console_msg)
+            try:
+                from app.config import settings
+                if settings.ENABLE_FILE_LOGGING:
+                    _llm_failure_logger.warning(
+                        "\n%s\n上下文: %s\n错误: %s\n%s",
+                        "=" * 60,
+                        f"{adapter_name} 触发429限流 | 第{attempt}次重试 | 等待{wait_secs:.0f}s",
+                        error_detail,
+                        "=" * 60,
+                    )
+            except Exception:
+                pass
+        else:
+            logger.warning(
+                f"[{adapter_name}] 请求失败 ({error_type}) — "
+                f"第 {attempt} 次重试，等待 {wait_secs:.0f}s | {error_detail}"
+            )
+
+    return _before_sleep
+
+
+def _retry_after_wait(retry_state) -> float:
+    """
+    429 重试等待策略（供各 LLM 适配器共用）：
+    1. 优先读取响应头 Retry-After / x-ratelimit-reset-after
+       （openai SDK 的 RateLimitError 继承 APIStatusError，携带 .response 对象）
+    2. 兜底指数退避：4s → 8s → 16s → 32s → 64s → 120s（上限）
+    """
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    if exc is not None:
+        try:
+            response = getattr(exc, "response", None)
+            headers = getattr(response, "headers", None)
+            if headers is not None:
+                raw = (
+                    headers.get("retry-after")
+                    or headers.get("Retry-After")
+                    or headers.get("x-ratelimit-reset-after")
+                )
+                if raw is not None:
+                    wait_secs = float(raw) + 1.0  # +1s 保险边距，避免边界竞争
+                    logger.info(
+                        f"[LLMAdapter] 读取到 Retry-After={float(raw):.0f}s，"
+                        f"等待 {wait_secs:.0f}s 后重试"
+                    )
+                    return min(wait_secs, 180.0)  # 最多等 3 分钟
+        except Exception:
+            pass
+    # 兜底：指数退避 2×2^n，上限 120s
+    # 各次等待：4s → 8s → 16s → 32s → 64s → 120s
+    attempt = retry_state.attempt_number
+    return min(2.0 * (2.0 ** attempt), 120.0)
 
 
 class BaseLLMAdapter(ABC):

--- a/app/services/llm/custom_adapter.py
+++ b/app/services/llm/custom_adapter.py
@@ -26,6 +26,9 @@ class CustomAdapter(BaseLLMAdapter):
         super().__init__(api_key, base_url, **kwargs)
         self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
+    async def aclose(self) -> None:
+        await self.client.close()
+
     async def generate(
         self,
         messages: List[LLMMessage],

--- a/app/services/llm/dashscope_adapter.py
+++ b/app/services/llm/dashscope_adapter.py
@@ -10,9 +10,9 @@ import logging
 from typing import AsyncIterator, List, Optional
 
 from openai import AsyncOpenAI, RateLimitError, APIConnectionError, InternalServerError
-from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+from tenacity import retry, stop_after_attempt, retry_if_exception_type
 
-from app.services.llm.adapter import BaseLLMAdapter
+from app.services.llm.adapter import BaseLLMAdapter, _retry_after_wait, _make_before_sleep_log
 from app.schemas.llm import LLMMessage, LLMResponse
 
 logger = logging.getLogger(__name__)
@@ -39,12 +39,10 @@ class DashScopeAdapter(BaseLLMAdapter):
         await self.client.close()
 
     @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=2, min=2, max=30),
+        stop=stop_after_attempt(6),
+        wait=_retry_after_wait,
         retry=retry_if_exception_type((RateLimitError, TimeoutError, ConnectionError, asyncio.TimeoutError, APIConnectionError, InternalServerError)),
-        before_sleep=lambda state: logger.warning(
-            f"[DashScopeAdapter] 重试第 {state.attempt_number} 次"
-        ),
+        before_sleep=_make_before_sleep_log("DashScopeAdapter"),
     )
     async def generate(
         self,

--- a/app/services/llm/dashscope_adapter.py
+++ b/app/services/llm/dashscope_adapter.py
@@ -35,6 +35,9 @@ class DashScopeAdapter(BaseLLMAdapter):
             base_url=self.base_url,
         )
 
+    async def aclose(self) -> None:
+        await self.client.close()
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=2, max=30),

--- a/app/services/llm/gemini_adapter.py
+++ b/app/services/llm/gemini_adapter.py
@@ -34,6 +34,9 @@ class GeminiAdapter(BaseLLMAdapter):
             max_retries=0,  # 禁用 SDK 内置重试，由 tenacity 统一管理，避免双重重试叠加
         )
 
+    async def aclose(self) -> None:
+        await self.client.close()
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=10, max=60),

--- a/app/services/llm/gemini_adapter.py
+++ b/app/services/llm/gemini_adapter.py
@@ -31,11 +31,12 @@ class GeminiAdapter(BaseLLMAdapter):
         self.client = AsyncOpenAI(
             api_key=api_key or "dummy-key",
             base_url=self.base_url,
+            max_retries=0,  # 禁用 SDK 内置重试，由 tenacity 统一管理，避免双重重试叠加
         )
 
     @retry(
         stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=2, min=2, max=30),
+        wait=wait_exponential(multiplier=2, min=10, max=60),
         retry=retry_if_exception_type((RateLimitError, TimeoutError, ConnectionError, asyncio.TimeoutError, APIConnectionError, InternalServerError)),
         before_sleep=lambda state: logger.warning(
             f"[GeminiAdapter] 重试第 {state.attempt_number} 次"

--- a/app/services/llm/gemini_adapter.py
+++ b/app/services/llm/gemini_adapter.py
@@ -9,9 +9,9 @@ import logging
 from typing import AsyncIterator, List, Optional
 
 from openai import AsyncOpenAI, RateLimitError, APIConnectionError, InternalServerError
-from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+from tenacity import retry, stop_after_attempt, retry_if_exception_type
 
-from app.services.llm.adapter import BaseLLMAdapter
+from app.services.llm.adapter import BaseLLMAdapter, _retry_after_wait, _make_before_sleep_log
 from app.schemas.llm import LLMMessage, LLMResponse
 
 logger = logging.getLogger(__name__)
@@ -38,12 +38,10 @@ class GeminiAdapter(BaseLLMAdapter):
         await self.client.close()
 
     @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=2, min=10, max=60),
+        stop=stop_after_attempt(6),
+        wait=_retry_after_wait,
         retry=retry_if_exception_type((RateLimitError, TimeoutError, ConnectionError, asyncio.TimeoutError, APIConnectionError, InternalServerError)),
-        before_sleep=lambda state: logger.warning(
-            f"[GeminiAdapter] 重试第 {state.attempt_number} 次"
-        ),
+        before_sleep=_make_before_sleep_log("GeminiAdapter"),
     )
     async def generate(
         self,

--- a/app/services/llm/openai_adapter.py
+++ b/app/services/llm/openai_adapter.py
@@ -21,6 +21,9 @@ class OpenAIAdapter(BaseLLMAdapter):
             base_url=base_url,
         )
 
+    async def aclose(self) -> None:
+        await self.client.close()
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=2, max=30),

--- a/app/services/llm/openai_adapter.py
+++ b/app/services/llm/openai_adapter.py
@@ -3,9 +3,9 @@ import logging
 from typing import AsyncIterator, List, Optional
 
 from openai import AsyncOpenAI, RateLimitError, APIStatusError, APIConnectionError, InternalServerError
-from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+from tenacity import retry, stop_after_attempt, retry_if_exception_type
 
-from app.services.llm.adapter import BaseLLMAdapter
+from app.services.llm.adapter import BaseLLMAdapter, _retry_after_wait, _make_before_sleep_log
 from app.schemas.llm import LLMMessage, LLMResponse
 
 logger = logging.getLogger(__name__)
@@ -25,12 +25,10 @@ class OpenAIAdapter(BaseLLMAdapter):
         await self.client.close()
 
     @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=2, min=2, max=30),
+        stop=stop_after_attempt(6),
+        wait=_retry_after_wait,
         retry=retry_if_exception_type((RateLimitError, TimeoutError, ConnectionError, asyncio.TimeoutError, APIConnectionError, InternalServerError)),
-        before_sleep=lambda state: logger.warning(
-            f"[OpenAIAdapter] 重试第 {state.attempt_number} 次"
-        ),
+        before_sleep=_make_before_sleep_log("OpenAIAdapter"),
     )
     async def generate(
         self,

--- a/app/services/wiki_generator.py
+++ b/app/services/wiki_generator.py
@@ -314,6 +314,7 @@ Rules:
 - subsections: 3-6 items covering the page topic
 - diagrams: 0-2 diagrams (only if genuinely useful; omit for config/testing pages)
 - key_references: 3-8 most important code locations
+- diagram ids MUST be exactly "DIAGRAM_1", "DIAGRAM_2", etc. (sequential integers, no custom names)
 """
 
 PAGE_DIAGRAM_PROMPT = """Generate ONLY the diagrams listed below. No prose, no explanations.
@@ -1227,6 +1228,20 @@ def _merge_diagrams_into_prose(prose: str, diagrams_raw: str) -> str:
     return re.sub(r'\[DIAGRAM_\d+\]', '', result)
 
 
+def _fix_bold_formatting(content: str) -> str:
+    """修复 LLM 输出的 '** text**' 错误加粗格式（** 后紧跟空格导致 Markdown 不渲染）。
+    仅处理代码围栏以外的正文段落，避免误改代码块中的 ** 幂运算符。
+    """
+    # 按代码围栏分割：偶数索引为正文，奇数索引为代码块
+    parts = re.split(r'(```[\s\S]*?```)', content)
+    fixed = []
+    for i, part in enumerate(parts):
+        if i % 2 == 0:
+            part = re.sub(r'\*\*\s+(\S)', r'**\1', part)
+        fixed.append(part)
+    return ''.join(fixed)
+
+
 async def _generate_page_content(
     adapter, model: str, page_data: dict,
     section_title: str, repo_name: str, code_context: str,
@@ -1241,6 +1256,9 @@ async def _generate_page_content(
     """
     # Agent 1：规划（串行，为后续两个 Agent 提供上下文）
     plan = await _plan_page(adapter, model, page_data, section_title, repo_name, code_context)
+    # 归一化 diagram ID：无论 LLM 输出何种自定义名称，统一重映射为 DIAGRAM_N
+    for _i, _d in enumerate(plan.get("diagrams", []), 1):
+        _d["id"] = f"DIAGRAM_{_i}"
     logger.info(
         f"[WikiGenerator] 页面规划完成: {page_data['title']} "
         f"| 子章节={len(plan.get('subsections', []))} "
@@ -1295,6 +1313,7 @@ async def _generate_page_content(
                 raise
 
     # 后处理流水线
+    content = _fix_bold_formatting(content)
     content = process_diagram_specs(content)
     content = await retry_failed_diagram_specs(content, adapter, model)
     content = await validate_and_fix_mermaid(adapter, model, content)

--- a/app/services/wiki_generator.py
+++ b/app/services/wiki_generator.py
@@ -955,6 +955,7 @@ async def generate_wiki(
         )
     else:
         logger.info(f"[WikiGenerator] Wiki 生成完成: wiki_id={wiki.id} 共={total_pages} 页（含快速上手2页）")
+    await adapter.aclose()
     return {"wiki_id": wiki.id, "total_pages": total_pages, "skipped_pages": skipped_count}
 
 
@@ -1010,6 +1011,7 @@ async def regenerate_specific_pages(
 
     if not pages:
         logger.warning(f"[WikiGenerator] 未找到任何指定页面: page_ids={page_ids}")
+        await adapter.aclose()
         return {"wiki_id": wiki.id, "total_pages": 0, "skipped_pages": 0}
 
     # 分离快速上手页和技术页
@@ -1098,6 +1100,7 @@ async def regenerate_specific_pages(
                 f"[WikiGenerator] 快速上手导航页同步更新失败（不影响已更新的技术页）: {e}"
             )
 
+    await adapter.aclose()
     return {"wiki_id": wiki.id, "total_pages": updated, "skipped_pages": skipped}
 
 
@@ -1947,6 +1950,7 @@ async def update_wiki_incrementally(
     if progress_callback:
         await progress_callback(99, f"增量更新完成：已更新 {updated_count} 个页面")
 
+    await adapter.aclose()
     return {
         "status": "updated",
         "wiki_id": wiki.id,

--- a/app/services/wiki_generator.py
+++ b/app/services/wiki_generator.py
@@ -27,8 +27,38 @@ from app.services.token_degradation import is_token_overflow, generate_with_degr
 from app.config import settings
 
 logger = logging.getLogger(__name__)
+_llm_failure_logger = logging.getLogger("llm.failures")
 
-# ============================================================
+_LLM_FAILURE_SEP = "=" * 80
+
+
+def _log_llm_failure(
+    context: str,
+    messages: list,
+    response: str = "",
+    error: str = "",
+) -> None:
+    """将 LLM 调用失败的完整 prompt 和响应写入 llm_failures.log（仅在 ENABLE_FILE_LOGGING=true 时生效）。"""
+    if not settings.ENABLE_FILE_LOGGING:
+        return
+    prompt_parts = []
+    for msg in messages:
+        role = msg.role if hasattr(msg, "role") else msg.get("role", "?")
+        content = msg.content if hasattr(msg, "content") else msg.get("content", "")
+        # 截断超长 prompt，避免单条日志过大（最多 8000 字符/消息）
+        if len(content) > 8000:
+            content = content[:8000] + "\n... [truncated]"
+        prompt_parts.append(f"[{role}]:\n{content}")
+    prompt_text = "\n\n".join(prompt_parts)
+    _llm_failure_logger.error(
+        "\n%s\n上下文: %s\n错误: %s\n--- PROMPT ---\n%s\n--- RESPONSE ---\n%s\n%s",
+        _LLM_FAILURE_SEP,
+        context,
+        error or "(无)",
+        prompt_text or "(无)",
+        response or "(empty)",
+        _LLM_FAILURE_SEP,
+    )
 # 图表生成 System Prompt（JSON spec 格式）
 # ============================================================
 MERMAID_CONSTRAINT_PROMPT = """
@@ -751,11 +781,28 @@ async def generate_wiki(
         LLMMessage(role="user", content=WIKI_OUTLINE_PROMPT.format(**repo_summary, language=language)),
     ]
 
-    outline_response = await adapter.generate_with_rate_limit(
-        messages=outline_messages, model=model, temperature=0.3,
-    )
+    outline = None
+    _last_outline_resp = ""
+    for _attempt in range(3):
+        outline_response = await adapter.generate_with_rate_limit(
+            messages=outline_messages, model=model, temperature=0.3,
+        )
+        _last_outline_resp = outline_response.content
+        outline = _parse_wiki_outline(outline_response.content)
+        if outline is not None:
+            break
+        # 每次格式错误立即记录，不等到全部失败，方便追踪哪次返回有问题
+        _log_llm_failure(
+            context=f"Wiki大纲生成-第{_attempt + 1}次（repo_id={repo_id}）",
+            messages=outline_messages,
+            response=_last_outline_resp,
+            error="XML解析失败（LLM返回格式不符合 <wiki_structure> 要求）",
+        )
+        logger.warning(f"[WikiGenerator] 大纲解析失败，第 {_attempt + 1}/3 次重试...")
+    if outline is None:
+        logger.warning("[WikiGenerator] 大纲解析连续失败，降级为默认大纲")
+        outline = _default_outline()
 
-    outline = _parse_wiki_outline(outline_response.content)
     logger.info(f"[WikiGenerator] 大纲解析完成: {len(outline['sections'])} 个章节")
 
     # 注入快速上手章节结构（order=0），其他章节 order 各加 1
@@ -1063,6 +1110,12 @@ async def _plan_page(
         return _json.loads(raw)
     except Exception as e:
         logger.warning(f"[WikiGenerator] 页面规划失败，使用默认规划: {e}")
+        _log_llm_failure(
+            context=f"页面规划（页面: {page_data.get('title', '?')}）",
+            messages=messages,
+            response=raw if 'raw' in dir() else "",
+            error=f"JSON解析失败: {e}",
+        )
         return {
             "subsections": ["Overview", "Implementation", "Configuration"],
             "diagrams": [{"id": "DIAGRAM_1", "type": "flowchart", "description": "Component relationships"}],
@@ -1095,6 +1148,11 @@ async def _generate_diagrams_only(
         return resp.content
     except Exception as e:
         logger.warning(f"[WikiGenerator] 图表生成失败: {e}")
+        _log_llm_failure(
+            context=f"图表生成（页面: {page_data['title']}）",
+            messages=messages,
+            error=str(e),
+        )
         return ""
 
 
@@ -1126,6 +1184,11 @@ async def _generate_prose_only(
         return resp.content
     except Exception as e:
         logger.warning(f"[WikiGenerator] 正文生成失败: {e}")
+        _log_llm_failure(
+            context=f"正文生成（页面: {page_data['title']}）",
+            messages=messages,
+            error=str(e),
+        )
         return ""
 
 
@@ -1180,6 +1243,13 @@ async def _generate_page_content(
 
     # 降级兜底：两个 Agent 都失败时回退到单 Agent
     if not content.strip():
+        # 记录两个 Agent 的实际返回，便于判断是 API 错误还是返回了空内容
+        _log_llm_failure(
+            context=f"三智能体均返回空内容（页面: {page_data['title']}），降级为单Agent",
+            messages=[],
+            response=f"[prose_raw]\n{prose_raw or '(empty)'}\n\n[diagrams_raw]\n{diagrams_raw or '(empty)'}",
+            error="两个 Agent 均返回空字符串（可能是 API 成功但内容为空，或 exception 已单独记录）",
+        )
         logger.warning(f"[WikiGenerator] 三智能体均失败，降级为单 Agent: {page_data['title']}")
         messages = [
             LLMMessage(role="system", content=MERMAID_CONSTRAINT_PROMPT),
@@ -1196,6 +1266,11 @@ async def _generate_page_content(
             response = await adapter.generate_with_rate_limit(messages=messages, model=model, temperature=0.5)
             content = response.content
         except Exception as e:
+            _log_llm_failure(
+                context=f"单Agent降级（页面: {page_data['title']}）",
+                messages=messages,
+                error=str(e),
+            )
             if is_token_overflow(e):
                 content = await generate_with_degradation(
                     adapter, model, page_data, section_title, repo_name,
@@ -1228,8 +1303,8 @@ async def _get_repo_summary(db: AsyncSession, repo_id: str, collection) -> dict:
     language_stats = "unknown"
 
     try:
-        # 获取更多 chunk 用于提取丰富的仓库信息
-        results = collection.get(limit=500, include=["metadatas"])
+        # 获取所有 chunk 的元数据（仅 metadatas，无向量/文档，内存开销极小）
+        results = collection.get(limit=None, include=["metadatas"])
         if results and results.get("metadatas"):
             file_counts: Dict[str, int] = {}
 
@@ -1260,22 +1335,31 @@ async def _get_repo_summary(db: AsyncSession, repo_id: str, collection) -> dict:
             key_files = sorted(file_counts.keys(),
                                key=lambda f: file_counts[f], reverse=True)[:10]
 
-            # 构建文件树字符串（按目录分组）
+            # 构建文件树字符串（按目录分组，覆盖所有目录）
             dirs: Dict[str, list] = {}
-            for fp in sorted(file_summary_map.keys())[:50]:
+            for fp in sorted(file_summary_map.keys()):
                 parts = fp.replace("\\", "/").split("/")
                 d = "/".join(parts[:-1]) or "(root)"
                 dirs.setdefault(d, []).append(parts[-1])
             file_tree_lines = []
-            for d, files in sorted(dirs.items())[:20]:
+            for d, files in sorted(dirs.items()):
                 file_tree_lines.append(f"  {d}/")
-                for f in files[:10]:
+                for f in files[:15]:
                     file_tree_lines.append(f"    {f}")
             file_tree = "\n".join(file_tree_lines) or "(empty)"
+            # 字符预算：超出时截断并提示
+            if len(file_tree) > 6000:
+                file_tree = file_tree[:6000] + "\n  ... (truncated)"
 
-            # 构建文件摘要字符串（含函数/类）
+            # 构建文件摘要字符串（按 chunk 数量排序，最重要的文件优先）
+            top_files_by_importance = sorted(
+                file_counts.keys(), key=lambda f: file_counts[f], reverse=True
+            )[:50]
             file_summaries_lines = []
-            for fp, info in list(file_summary_map.items())[:20]:
+            for fp in top_files_by_importance:
+                if fp not in file_summary_map:
+                    continue
+                info = file_summary_map[fp]
                 line = f"- {fp}"
                 if info["classes"]:
                     line += f"  classes: {', '.join(info['classes'][:5])}"
@@ -1428,7 +1512,7 @@ async def _retrieve_code_context(
     return "\n\n".join(parts)
 
 
-def _parse_wiki_outline(content: str) -> dict:
+def _parse_wiki_outline(content: str) -> Optional[dict]:
     """
     解析 LLM 返回的 XML 大纲。
     支持容错：提取 XML 片段，忽略前后的多余文本。
@@ -1453,6 +1537,7 @@ def _parse_wiki_outline(content: str) -> dict:
             }
         ]
     }
+    解析失败时返回 None，由调用方决定是否重试。
     """
     # 尝试提取 <wiki_structure>...</wiki_structure> 片段
     xml_match = re.search(
@@ -1460,16 +1545,16 @@ def _parse_wiki_outline(content: str) -> dict:
         content, re.DOTALL
     )
     if not xml_match:
-        logger.warning("[WikiGenerator] XML 大纲解析失败，使用默认大纲")
-        return _default_outline()
+        logger.warning("[WikiGenerator] 未找到 <wiki_structure> 标签，解析失败")
+        return None
 
     xml_text = xml_match.group(0)
 
     try:
         root = ET.fromstring(xml_text)
     except ET.ParseError as e:
-        logger.warning(f"[WikiGenerator] XML 解析错误: {e}，使用默认大纲")
-        return _default_outline()
+        logger.warning(f"[WikiGenerator] XML 解析错误: {e}")
+        return None
 
     # 解析 title
     title_el = root.find("title")

--- a/app/services/wiki_generator.py
+++ b/app/services/wiki_generator.py
@@ -902,9 +902,21 @@ async def generate_wiki(
 
             if isinstance(result, Exception):
                 logger.error(
-                    f"[WikiGenerator] 页面生成失败，跳过: {p_data['title']} — {result}"
+                    f"[WikiGenerator] 页面生成失败，写入空页面以供后续重新生成: {p_data['title']} — {result}"
                 )
                 skipped_count += 1
+                # 仍写入空 WikiPage，使前端可以选中并重新生成
+                page = WikiPage(
+                    section_id=section_map[section_title].id,
+                    title=p_data["title"],
+                    importance=p_data.get("importance", "medium"),
+                    content_md=None,
+                    relevant_files=p_data.get("relevant_files"),
+                    order_index=p_data["order"],
+                    summary=None,
+                )
+                db.add(page)
+                await db.commit()
                 continue
 
             _, _, content, summary = result
@@ -1303,15 +1315,26 @@ async def _get_repo_summary(db: AsyncSession, repo_id: str, collection) -> dict:
     language_stats = "unknown"
 
     try:
-        # 获取所有 chunk 的元数据（仅 metadatas，无向量/文档，内存开销极小）
-        results = collection.get(limit=None, include=["metadatas"])
-        if results and results.get("metadatas"):
+        # 分批获取所有 chunk 的元数据，避免 SQLite "too many SQL variables" 错误
+        # （limit=None 会生成超长 IN 子句，chunk 数 > 999 时必然崩溃）
+        _BATCH = 500
+        all_metadatas: list = []
+        _offset = 0
+        while True:
+            _batch = collection.get(limit=_BATCH, offset=_offset, include=["metadatas"])
+            _metas = (_batch or {}).get("metadatas") or []
+            all_metadatas.extend(_metas)
+            if len(_metas) < _BATCH:
+                break
+            _offset += _BATCH
+
+        if all_metadatas:
             file_counts: Dict[str, int] = {}
 
             # 构建文件摘要（函数/类清单）
             file_summary_map: Dict[str, dict] = {}  # file_path -> {language, functions: [], classes: []}
 
-            for meta in results["metadatas"]:
+            for meta in all_metadatas:
                 if meta:
                     lang = meta.get("language", "")
                     if lang:

--- a/doc/API.md
+++ b/doc/API.md
@@ -1,6 +1,6 @@
 # API 接口文档
 
-> **版本**: 1.7.0 | **最后更新**: 2026-03-01
+> **版本**: 1.8.0 | **最后更新**: 2026-03-03
 >
 > Base URL: `http://localhost:8000`
 
@@ -9,6 +9,64 @@
 ## 概述
 
 Open-DeepWiki REST API，使用 FastAPI 构建，支持 JSON 请求/响应和 SSE 流式推送。
+
+当 `AUTH_ENABLED=true` 时，除 `/health`、`/api/auth/status`、`/api/auth/login` 外，所有端点均需在请求头携带有效会话 token：
+
+```
+Authorization: Bearer <token>
+```
+
+SSE 端点（`EventSource` 不支持自定义 header）改用查询参数传递：`?token=<token>`。
+
+---
+
+## 访问鉴权
+
+> 以下三个端点始终公开，无需鉴权。
+
+### GET /api/auth/status
+
+查询鉴权是否已启用，前端据此决定是否展示登录页。
+
+**响应 200**:
+```json
+{ "enabled": true }
+```
+
+---
+
+### POST /api/auth/login
+
+验证访问口令，成功后颁发会话 token（存储于 Redis，有效期由 `AUTH_SESSION_EXPIRE_HOURS` 控制，默认 168 小时）。
+
+**请求体**:
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `password` | string | 是 | 访问口令（对应 `.env` 中 `AUTH_PASSWORD`） |
+
+**成功响应 200**:
+```json
+{ "token": "随机生成的会话 token" }
+```
+
+**错误响应**:
+| 状态码 | 说明 |
+|--------|------|
+| 401 | 口令错误 |
+| 503 | 服务端未配置 `AUTH_PASSWORD` |
+
+---
+
+### POST /api/auth/logout
+
+使当前会话 token 立即失效。
+
+**请求头**: `Authorization: Bearer <token>`
+
+**响应 200**:
+```json
+{ "message": "已登出" }
+```
 
 ---
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -478,6 +478,198 @@ es.onmessage = (event) => {
 
 ---
 
+## 系统管理接口
+
+> 所有端点前缀为 `/api/system`，由 `app/api/system.py` 实现。
+
+### GET /api/system/config
+
+获取当前生效的系统配置，API Key 已脱敏（仅保留末 4 位，前缀显示 `****`）。
+
+**响应示例**:
+```json
+{
+    "llm": {
+        "default_provider": "dashscope",
+        "default_model": "qwen-plus",
+        "openai_api_key": "****3f9a",
+        "openai_base_url": "",
+        "dashscope_api_key": "****cedf",
+        "google_api_key": "",
+        "custom_base_url": "",
+        "custom_api_key": ""
+    },
+    "embedding": {
+        "api_key": "****cedf",
+        "base_url": "",
+        "model": "text-embedding-v3"
+    },
+    "wiki_language": "Chinese",
+    "is_customized": true
+}
+```
+
+`is_customized` 为 `false` 时表示尚未通过面板保存过配置，当前值来自 `.env`。
+
+---
+
+### PUT /api/system/config
+
+更新系统配置，写入 `data/system_config.json`，立即生效（无需重启）。
+
+**请求体**（所有字段可选，仅传需修改的字段）:
+```json
+{
+    "llm": {
+        "default_provider": "openai",
+        "default_model": "gpt-4o",
+        "openai_api_key": "sk-xxxx"
+    },
+    "wiki_language": "English"
+}
+```
+
+**响应**: `{ "status": "ok" }`
+
+> 若某字段值为脱敏格式（如 `****cedf`），后端自动忽略该字段，保留已存储的真实值。
+
+---
+
+### POST /api/system/config/test
+
+使用指定凭证测试 LLM 供应商 API 连通性，发送一次 `max_tokens=1` 的 Chat Completions 请求。
+
+**请求体**:
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `provider` | string | 是 | `openai` / `dashscope` / `gemini` / `custom` |
+| `api_key` | string | 否 | 留空或传脱敏值时自动读取已保存的真实 Key |
+| `base_url` | string | 否 | 留空时使用供应商默认地址 |
+| `model` | string | 否 | 测试使用的模型名；留空时读取 `DEFAULT_LLM_MODEL`，仍为空则返回错误 |
+
+**响应示例（成功）**:
+```json
+{ "success": true, "latency_ms": 843, "error": null }
+```
+
+**响应示例（失败）**:
+```json
+{ "success": false, "latency_ms": null, "error": "AuthenticationError: Incorrect API key" }
+```
+
+---
+
+### GET /api/system/health
+
+并发检查各服务健康状态。
+
+**响应示例**:
+```json
+{
+    "services": {
+        "database": { "status": "ok" },
+        "redis":    { "status": "ok" },
+        "chromadb": { "status": "ok" },
+        "celery":   { "status": "ok", "active_tasks": 1 }
+    }
+}
+```
+
+`status` 可选值：`ok` / `error` / `offline` / `unknown`
+
+---
+
+### GET /api/system/tasks
+
+分页查询任务列表，支持按状态筛选。
+
+**Query 参数**:
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `page` | int | 页码，默认 1 |
+| `per_page` | int | 每页条数，默认 15 |
+| `status` | string | 状态筛选；`running` 为特殊值，映射为所有活跃状态（`pending/cloning/parsing/embedding/generating`） |
+
+**响应示例**:
+```json
+{
+    "items": [
+        {
+            "id": "uuid",
+            "repo_id": "uuid",
+            "repo_url": "https://github.com/owner/repo",
+            "type": "full_process",
+            "status": "completed",
+            "progress_pct": 100,
+            "current_stage": "处理完成",
+            "created_at": "2026-03-01T12:00:00Z",
+            "completed_at": "2026-03-01T12:05:00Z"
+        }
+    ],
+    "total": 42,
+    "page": 1,
+    "per_page": 15,
+    "pages": 3
+}
+```
+
+---
+
+### POST /api/system/tasks/{task_id}/cancel
+
+取消指定任务。已处于终态（`completed`/`failed`/`cancelled`/`interrupted`）的任务返回 400。
+
+**响应**: `{ "status": "ok", "task_id": "uuid" }`
+
+---
+
+### GET /api/system/storage
+
+查询各存储目录磁盘占用。
+
+**响应示例**:
+```json
+{
+    "repos": { "path": "./repos", "size_bytes": 52428800, "size_human": "50.0 MB" },
+    "chromadb": { "path": "./data/chromadb", "size_bytes": 10485760, "size_human": "10.0 MB" },
+    "database": { "path": "./data/deepwiki.db", "size_bytes": 1048576, "size_human": "1.0 MB" },
+    "total_human": "61.0 MB"
+}
+```
+
+---
+
+### POST /api/system/cleanup/scan
+
+扫描孤儿数据（不属于任何仓库的 `repos/` 目录和 ChromaDB 集合），只读预览，不执行删除。
+
+**响应示例**:
+```json
+{
+    "orphan_dirs": ["repos/abc123", "repos/def456"],
+    "orphan_collections": ["col_abc123"],
+    "orphan_count": 3
+}
+```
+
+---
+
+### POST /api/system/cleanup/execute
+
+重新扫描并删除孤儿数据，返回清理结果。
+
+**响应示例**:
+```json
+{
+    "cleaned_dirs": 2,
+    "cleaned_collections": 1,
+    "reclaimed_bytes": 62914560,
+    "reclaimed_human": "60.0 MB"
+}
+```
+
+---
+
 ## 错误恢复指南
 
 ### 故障场景与推荐操作

--- a/doc/PIPELINE.md
+++ b/doc/PIPELINE.md
@@ -89,7 +89,7 @@ pending
 
 ### INCREMENTAL_SYNC 的特殊规则
 
-- 若 0 个文件变更（全部 hash 匹配） → 直接进入 `embedding` 阶段（跳过），然后 `generating`，最终 `completed`
+- 若 0 个文件变更（全部 hash 匹配） → 跳过 `embedding`、跳过 `generating`（Wiki 不重生成），直接 `completed`
 - INCREMENTAL_SYNC 允许 chunks = 0（表示无变更），不视为失败
 
 ---
@@ -228,16 +228,20 @@ INCREMENTAL_SYNC 触发（通过 /sync 端点或重新提交同 URL）
   │     ├── git fetch origin {branch}
   │     ├── git diff HEAD..origin/{branch} --name-status → 获取变更文件列表
   │     ├── git merge origin/{branch} → 拉取最新代码
-  │     └── ChromaDB 清理: 删除状态为 'D' 的文件对应的所有 chunk 向量
+  │     ├── ChromaDB 清理: 删除状态为 'D' 的文件对应的所有 chunk 向量
+  │     └── 代码库索引增量更新: update_codebase_index_for_files()（仅变更文件）
   │
   └── Stage 2-4: 正常四阶段流程（force_full=False）
         ├── Parser: 文件 hash 未变 → 跳过（FileState 命中）
         ├── Parser: 文件 hash 已变 → 重新解析
         ├── Embedder: 仅处理变更文件 chunks，更新 FileState
-        └── Stage 4 (Wiki): update_wiki_incrementally()
-              ├── 脏页比例 ≤ 65% → 增量更新脏页，保留干净页
-              ├── 脏页比例 > 65% → 不更新，返回建议全量重生成
-              └── Wiki 不存在   → 调用 generate_wiki() 全量生成
+        ├── Stage 3.5 (代码库索引): 增量同步时跳过（已在 Stage 1 完成）
+        └── Stage 4 (Wiki):
+              ├── 有变更文件 → update_wiki_incrementally()
+              │     ├── 脏页比例 ≤ 65% → 增量更新脏页，保留干净页
+              │     ├── 脏页比例 > 65% → 不更新，返回建议全量重生成
+              │     └── Wiki 不存在   → 调用 generate_wiki() 全量生成
+              └── 无变更文件 → 跳过 Wiki 生成，直接 completed
 ```
 
 ### Stage 1 分支逻辑（process_repo.py）
@@ -277,7 +281,7 @@ else:
 
 ### INCREMENTAL_SYNC 允许 chunks=0
 
-若所有文件 hash 均未变更，Parser 返回空 chunks，Embedder 无写入。Stage 4 仍会调用 `update_wiki_incrementally()`，此时脏页列表为空，直接返回不更新（跳过 Wiki 生成）。这是合法状态，不视为失败。
+若所有文件 hash 均未变更，Parser 返回空 chunks，Embedder 无写入，Stage 3.5 代码库索引已在 Stage 1 增量更新（无变更则跳过），Stage 4 Wiki 生成直接跳过，任务直接置为 `completed`。这是合法状态，不视为失败。
 
 ### repo.status 生命周期（增量）
 

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -1,6 +1,13 @@
 // 对话 API - 对应模块五（RAG + 对话）
 // 后端端点: GET /api/chat/stream?repo_id=&session_id=&query=
 
+const TOKEN_KEY = 'auth_token'
+
+function getAuthHeader(): Record<string, string> {
+  const token = localStorage.getItem(TOKEN_KEY)
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
 export interface ChunkRef {
   file_path: string
   start_line: number
@@ -18,7 +25,9 @@ export interface SessionMessage {
 
 export async function getChatSession(sessionId: string): Promise<{ session_id: string; messages: SessionMessage[] }> {
   const baseUrl = import.meta.env.VITE_API_BASE_URL || '/api'
-  const response = await fetch(`${baseUrl}/chat/sessions/${sessionId}`)
+  const response = await fetch(`${baseUrl}/chat/sessions/${sessionId}`, {
+    headers: getAuthHeader(),
+  })
   if (!response.ok) throw new Error(`Session not found: ${response.status}`)
   return response.json()
 }
@@ -41,6 +50,8 @@ export function createChatStream(options: ChatStreamOptions): EventSource {
     session_id: options.sessionId || '',
     query: options.query,
   })
+  const token = localStorage.getItem(TOKEN_KEY)
+  if (token) params.set('token', token)
   const url = `${baseUrl}/chat/stream?${params.toString()}`
 
   const eventSource = new EventSource(url)
@@ -99,7 +110,7 @@ export function createDeepResearchStream(options: DeepResearchStreamOptions): Ab
 
   fetch(`${baseUrl}/chat`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
     body: JSON.stringify({
       repo_id: options.repoId,
       session_id: options.sessionId || null,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,9 +1,20 @@
 import axios from 'axios'
 
+const TOKEN_KEY = 'auth_token'
+
 const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
   timeout: 30000,
   headers: { 'Content-Type': 'application/json' },
+})
+
+// 请求拦截器：自动附加会话 token
+apiClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem(TOKEN_KEY)
+  if (token) {
+    config.headers['Authorization'] = `Bearer ${token}`
+  }
+  return config
 })
 
 apiClient.interceptors.response.use(
@@ -14,6 +25,13 @@ apiClient.interceptors.response.use(
       switch (status) {
         case 400:
           console.error('请求参数错误:', data?.detail || data)
+          break
+        case 401:
+          // token 失效或未登录，清除本地凭证并跳转登录页
+          localStorage.removeItem(TOKEN_KEY)
+          if (window.location.pathname !== '/login') {
+            window.location.href = '/login'
+          }
           break
         case 404:
           console.error('资源不存在:', data?.detail)

--- a/frontend/src/api/wiki.ts
+++ b/frontend/src/api/wiki.ts
@@ -4,7 +4,7 @@ export interface WikiPage {
   id: string
   title: string
   importance: 'high' | 'medium' | 'low'
-  content_md: string
+  content_md: string | null
   relevant_files: string[]
   order_index: number
 }

--- a/frontend/src/components/WikiRegenerateDialog.vue
+++ b/frontend/src/components/WikiRegenerateDialog.vue
@@ -27,7 +27,7 @@ function hasEmptyPages(): boolean {
 const mode = ref<'full' | 'partial'>(hasEmptyPages() ? 'partial' : 'full')
 const selectedPageIds = ref<Set<string>>(new Set())
 
-function isPageEmpty(contentMd: string): boolean {
+function isPageEmpty(contentMd: string | null | undefined): boolean {
   return !contentMd || contentMd.trim() === ''
 }
 

--- a/frontend/src/components/WikiRegenerateDialog.vue
+++ b/frontend/src/components/WikiRegenerateDialog.vue
@@ -6,6 +6,7 @@ import { getSystemConfig } from '@/api/system'
 const props = defineProps<{
   wiki: WikiResponse | null
   visible: boolean
+  currentPageId?: string
 }>()
 
 const emit = defineEmits<{
@@ -241,6 +242,10 @@ function setSectionIndeterminate(el: HTMLInputElement | null, sectionId: string)
                     class="regen-checkbox"
                   />
                   <span class="regen-row__label">{{ page.title }}</span>
+                  <span
+                    v-if="page.id === currentPageId"
+                    class="regen-badge regen-badge--current"
+                  >当前页</span>
                   <span
                     v-if="isPageEmpty(page.content_md)"
                     class="regen-badge regen-badge--empty"
@@ -503,6 +508,18 @@ function setSectionIndeterminate(el: HTMLInputElement | null, sectionId: string)
   padding: 2px 6px;
   border-radius: 4px;
   line-height: 1.4;
+}
+
+.regen-badge--current {
+  color: #2563eb;
+  background: rgba(37, 99, 235, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.25);
+}
+
+[data-theme="dark"] .regen-badge--current {
+  color: #60a5fa;
+  background: rgba(96, 165, 250, 0.1);
+  border-color: rgba(96, 165, 250, 0.2);
 }
 
 .regen-badge--empty {

--- a/frontend/src/composables/useEventSource.ts
+++ b/frontend/src/composables/useEventSource.ts
@@ -18,7 +18,9 @@ export function useEventSource() {
     _closeOne(taskId)
     conns.set(taskId, { es: null, timer: null, attempts: 0 })
     const base = import.meta.env.VITE_API_BASE_URL || '/api'
-    _doConnect(`${base}/tasks/${taskId}/stream`, taskId)
+    const token = localStorage.getItem('auth_token')
+    const tokenParam = token ? `?token=${encodeURIComponent(token)}` : ''
+    _doConnect(`${base}/tasks/${taskId}/stream${tokenParam}`, taskId)
   }
 
   function _doConnect(url: string, taskId: string) {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,8 +1,15 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 
 const router = createRouter({
   history: createWebHistory(),
   routes: [
+    {
+      path: '/login',
+      name: 'login',
+      component: () => import('@/views/LoginView.vue'),
+      meta: { title: '登录 - Open DeepWiki', public: true },
+    },
     {
       path: '/',
       name: 'home',
@@ -43,6 +50,34 @@ router.afterEach((to) => {
   if (to.meta?.title) {
     document.title = to.meta.title as string
   }
+})
+
+// 鉴权守卫：仅在首次导航时初始化 auth 状态，之后每次导航检查登录
+let authInitialized = false
+
+router.beforeEach(async (to) => {
+  const authStore = useAuthStore()
+
+  if (!authInitialized) {
+    await authStore.checkStatus()
+    authInitialized = true
+  }
+
+  // 鉴权未启用，全部放行
+  if (!authStore.authEnabled) return true
+
+  // 登录页等公开路由，直接放行
+  if (to.meta?.public) return true
+
+  // 未登录 → 跳转登录页，并记录目标路径以便登录后重定向
+  if (!authStore.isAuthenticated) {
+    return { name: 'login', query: { redirect: to.fullPath } }
+  }
+
+  // 已登录访问登录页 → 跳回首页
+  if (to.name === 'login') return { name: 'home' }
+
+  return true
 })
 
 export default router

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,0 +1,53 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import apiClient from '@/api/client'
+
+const TOKEN_KEY = 'auth_token'
+
+export const useAuthStore = defineStore('auth', () => {
+  const authEnabled = ref(false)
+  const isAuthenticated = ref(false)
+  const token = ref<string | null>(localStorage.getItem(TOKEN_KEY))
+
+  /**
+   * 查询后端鉴权是否启用，并验证本地 token 的有效性。
+   * 在路由守卫中每次初始化时调用一次。
+   */
+  async function checkStatus(): Promise<void> {
+    try {
+      const { data } = await apiClient.get('/auth/status')
+      authEnabled.value = data.enabled
+
+      if (!data.enabled) {
+        // 鉴权关闭，直接放行
+        isAuthenticated.value = true
+        return
+      }
+
+      // 有本地 token → 乐观认为已登录（后端 401 会触发拦截器清除）
+      isAuthenticated.value = !!token.value
+    } catch {
+      // 无法连接后端时不阻塞，保持当前状态
+      isAuthenticated.value = !!token.value
+    }
+  }
+
+  async function login(password: string): Promise<void> {
+    const { data } = await apiClient.post('/auth/login', { password })
+    token.value = data.token
+    localStorage.setItem(TOKEN_KEY, data.token)
+    isAuthenticated.value = true
+  }
+
+  async function logout(): Promise<void> {
+    try {
+      await apiClient.post('/auth/logout')
+    } finally {
+      token.value = null
+      localStorage.removeItem(TOKEN_KEY)
+      isAuthenticated.value = false
+    }
+  }
+
+  return { authEnabled, isAuthenticated, token, checkStatus, login, logout }
+})

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,0 +1,246 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+
+const router = useRouter()
+const route = useRoute()
+const authStore = useAuthStore()
+
+const password = ref('')
+const showPassword = ref(false)
+const errorMsg = ref('')
+const loading = ref(false)
+
+async function handleLogin() {
+  if (!password.value.trim()) {
+    errorMsg.value = '请输入登录口令'
+    return
+  }
+  loading.value = true
+  errorMsg.value = ''
+  try {
+    await authStore.login(password.value)
+    const redirect = (route.query.redirect as string) || '/'
+    router.replace(redirect)
+  } catch (e: any) {
+    const detail = e?.response?.data?.detail
+    errorMsg.value = detail || '口令错误，请重试'
+    password.value = ''
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="login-page">
+    <div class="login-card">
+      <div class="login-logo">
+        <span class="logo-icon">📖</span>
+        <span class="logo-text">Open DeepWiki</span>
+      </div>
+
+      <h1 class="login-title">访问验证</h1>
+      <p class="login-desc">请输入访问口令以继续</p>
+
+      <form class="login-form" @submit.prevent="handleLogin">
+        <div class="input-wrapper">
+          <input
+            :type="showPassword ? 'text' : 'password'"
+            v-model="password"
+            placeholder="输入访问口令"
+            class="password-input"
+            :class="{ 'input-error': errorMsg }"
+            autofocus
+            autocomplete="current-password"
+          />
+          <button
+            type="button"
+            class="toggle-btn"
+            @click="showPassword = !showPassword"
+            tabindex="-1"
+            :title="showPassword ? '隐藏口令' : '显示口令'"
+          >
+            <svg v-if="showPassword" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94"/>
+              <path d="M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19"/>
+              <line x1="1" y1="1" x2="23" y2="23"/>
+            </svg>
+            <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+              <circle cx="12" cy="12" r="3"/>
+            </svg>
+          </button>
+        </div>
+
+        <p v-if="errorMsg" class="error-msg">{{ errorMsg }}</p>
+
+        <button type="submit" class="login-btn" :disabled="loading">
+          <span v-if="loading" class="spinner"></span>
+          <span>{{ loading ? '验证中…' : '登录' }}</span>
+        </button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.login-page {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-primary);
+  padding: 24px;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 380px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-xl);
+  padding: 40px 36px;
+  box-shadow: var(--shadow-lg);
+}
+
+.login-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 28px;
+}
+
+.logo-icon {
+  font-size: 24px;
+}
+
+.logo-text {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.3px;
+}
+
+.login-title {
+  font-size: var(--font-size-2xl);
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+  letter-spacing: -0.5px;
+}
+
+.login-desc {
+  font-size: var(--font-size-sm);
+  color: var(--text-tertiary);
+  margin: 0 0 28px;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.input-wrapper {
+  position: relative;
+}
+
+.password-input {
+  width: 100%;
+  height: 44px;
+  padding: 0 44px 0 14px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color-strong);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: var(--font-size-base);
+  font-family: var(--font-sans);
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  box-sizing: border-box;
+}
+
+.password-input::placeholder {
+  color: var(--text-muted);
+}
+
+.password-input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+}
+
+.password-input.input-error {
+  border-color: var(--color-error);
+}
+
+.toggle-btn {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+}
+
+.toggle-btn:hover {
+  color: var(--text-secondary);
+}
+
+.toggle-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.error-msg {
+  font-size: var(--font-size-sm);
+  color: var(--color-error);
+  margin: 0;
+}
+
+.login-btn {
+  height: 44px;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.login-btn:hover:not(:disabled) {
+  background: var(--color-primary-dark);
+}
+
+.login-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255,255,255,0.35);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/frontend/src/views/RepoListView.vue
+++ b/frontend/src/views/RepoListView.vue
@@ -361,6 +361,16 @@ onMounted(async () => {
                 {{ repo.platform === 'github' ? '⬡' : repo.platform === 'gitlab' ? '🦊' : '☁' }}
               </span>
               <span class="platform-name">{{ repo.platform }}</span>
+              <span class="branch-badge">
+                <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                  <circle cx="5" cy="3.5" r="1.5"/>
+                  <circle cx="5" cy="12.5" r="1.5"/>
+                  <circle cx="11" cy="6.5" r="1.5"/>
+                  <path d="M5 5v5" stroke-linecap="round"/>
+                  <path d="M5 5.5C5 7.5 11 7.5 11 8" stroke-linecap="round"/>
+                </svg>
+                {{ repo.default_branch || 'main' }}
+              </span>
             </div>
             <h3 class="repo-card__name">{{ repo.name }}</h3>
           </div>
@@ -812,6 +822,27 @@ onMounted(async () => {
   font-size: var(--font-size-xs);
   color: var(--text-muted);
   text-transform: capitalize;
+}
+
+.branch-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-full);
+  padding: 1px 7px 1px 5px;
+  font-family: var(--font-mono);
+  line-height: 1.6;
+}
+
+.branch-badge svg {
+  width: 11px;
+  height: 11px;
+  flex-shrink: 0;
+  color: var(--text-muted);
 }
 
 .repo-card__name {

--- a/frontend/src/views/WikiView.vue
+++ b/frontend/src/views/WikiView.vue
@@ -488,6 +488,7 @@ watch(() => wikiStore.activePageId, async () => {
     <WikiRegenerateDialog
       v-if="showRegenerateDialog"
       :wiki="wikiStore.wiki"
+      :current-page-id="wikiStore.activePageId"
       v-model:visible="showRegenerateDialog"
       @confirm="handleRegenerateConfirm"
       @cancel="showRegenerateDialog = false"


### PR DESCRIPTION
Summary

  安全
  - 新增可选的口令登录鉴权系统（AUTH_ENABLED / AUTH_PASSWORD / AUTH_SESSION_EXPIRE_HOURS），基于 Redis 会话 token，支持
  Bearer header 和 SSE query param 双路验证
  - 前端新增 LoginView、auth store 及路由守卫，axios/EventSource/fetch 均自动携带凭证，401 自动跳转登录页

  LLM 网关稳定性
  - 统一四个适配器（OpenAI / DashScope / Gemini / Custom）的限流重试逻辑，优先读取 Retry-After 响应头
  - 修复 Gemini 限流处理与 Windows 环境下 httpx 连接池关闭时的事件循环报错

  日志与可观测性
  - 新增按进程类型（api / worker）分文件记录日志，专设 llm_failures.log 记录 LLM 完整请求/响应，默认关闭，可通过
  ENABLE_FILE_LOGGING=true 开启

  Wiki 生成质量
  - 修复 LLM 输出中加粗格式被错误剥离的问题，统一 Mermaid 图表节点 ID 生成规则
  - 修复空页面无法选中重生成及大型仓库 ChromaDB 查询参数溢出问题

  前端体验
  - 重生成对话框高亮当前页、仓库卡片展示当前追踪分支（branch badge）

  Test plan

  - AUTH_ENABLED=false 时访问所有页面正常，无任何鉴权拦截
  - AUTH_ENABLED=true 时未登录访问任意路由跳转 /login，口令正确后重定向原目标页
  - 登录后 token 有效期内（默认 7 天）刷新页面无需重新登录
  - 后端重启后旧 token 失效（Redis 未持久化场景），前端正确跳转登录页
  - SSE 进度推送和 AI 对话流在鉴权开启状态下正常工作
  - LLM 供应商返回 429 时自动重试并正确读取 Retry-After
  - 仓库列表卡片正确显示 default_branch 字段值