### PR TITLE
feat(frontend): 实现移动端响应式 UI 适配

### DIFF
--- a/frontend/src/assets/styles/main.css
+++ b/frontend/src/assets/styles/main.css
@@ -486,3 +486,39 @@ button {
     --sidebar-width: 260px;
   }
 }
+
+/* ---- Mobile: code overflow fixes ---- */
+
+/* Inline code only (not inside pre): allow wrapping */
+.markdown-body :not(pre) > code {
+  word-break: break-word;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+/* Code block container */
+.code-block {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+/* Code block pre: keep horizontal scroll, no wrapping */
+.code-block pre {
+  word-break: normal;
+  overflow-wrap: normal;
+  white-space: pre;
+}
+
+/* Markdown pre: cap width so it doesn't blow out layout */
+.markdown-body pre {
+  max-width: 100%;
+}
+
+/* Mobile table: horizontal scroll */
+@media (max-width: 768px) {
+  .markdown-body table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 
 const isDark = ref(false)
+const mobileMenuOpen = ref(false)
 
 function applyTheme(dark: boolean) {
   isDark.value = dark
@@ -11,6 +12,18 @@ function applyTheme(dark: boolean) {
 
 function toggleTheme() {
   applyTheme(!isDark.value)
+}
+
+function toggleMobileMenu() {
+  mobileMenuOpen.value = !mobileMenuOpen.value
+}
+
+function closeMobileMenu() {
+  mobileMenuOpen.value = false
+}
+
+function handleOverlayClick() {
+  mobileMenuOpen.value = false
 }
 
 onMounted(() => {
@@ -24,6 +37,10 @@ onMounted(() => {
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
     applyTheme(prefersDark)
   }
+})
+
+onUnmounted(() => {
+  mobileMenuOpen.value = false
 })
 </script>
 
@@ -57,8 +74,35 @@ onMounted(() => {
             <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
         </button>
+
+        <!-- Hamburger button: only visible on mobile -->
+        <button
+          class="hamburger-btn"
+          @click="toggleMobileMenu"
+          :aria-label="mobileMenuOpen ? '关闭菜单' : '打开菜单'"
+          :aria-expanded="mobileMenuOpen"
+        >
+          <!-- X icon when open -->
+          <svg v-if="mobileMenuOpen" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <!-- Hamburger icon when closed -->
+          <svg v-else viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
       </div>
     </div>
+
+    <!-- Mobile nav dropdown -->
+    <div v-if="mobileMenuOpen" class="mobile-nav" role="navigation" aria-label="移动端导航">
+      <RouterLink to="/" class="mobile-nav-link" @click="closeMobileMenu">首页</RouterLink>
+      <RouterLink to="/repos" class="mobile-nav-link" @click="closeMobileMenu">仓库</RouterLink>
+      <RouterLink to="/system" class="mobile-nav-link" @click="closeMobileMenu">系统管理</RouterLink>
+    </div>
+
+    <!-- Overlay backdrop -->
+    <div v-if="mobileMenuOpen" class="mobile-overlay" @click="handleOverlayClick" aria-hidden="true" />
   </header>
 </template>
 
@@ -72,10 +116,15 @@ onMounted(() => {
   z-index: 100;
 }
 
+/* When mobile menu is open the header expands, so remove fixed height constraint */
+.app-header:has(.mobile-nav) {
+  height: auto;
+}
+
 .header-content {
   max-width: 1600px;
   margin: 0 auto;
-  height: 100%;
+  height: var(--header-height);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -169,7 +218,96 @@ onMounted(() => {
   height: 16px;
 }
 
+/* Hamburger button: hidden by default, visible only on mobile */
+.hamburger-btn {
+  display: none;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  cursor: pointer;
+  color: var(--text-tertiary);
+  transition: all 0.15s;
+  padding: 0;
+}
+
+.hamburger-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-color-strong);
+}
+
+.hamburger-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* Mobile nav dropdown */
+.mobile-nav {
+  display: none;
+  flex-direction: column;
+  background: var(--bg-primary);
+  border-top: 1px solid var(--border-color);
+  padding: 8px 0;
+}
+
+.mobile-nav-link {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 20px;
+  font-size: var(--font-size-md);
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  border-left: 3px solid transparent;
+}
+
+.mobile-nav-link:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.mobile-nav-link.router-link-active {
+  color: var(--color-primary);
+  border-left-color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+[data-theme="dark"] .mobile-nav-link.router-link-active {
+  background: rgba(37, 99, 235, 0.1);
+}
+
+/* Overlay backdrop */
+.mobile-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  top: 0;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: -1;
+}
+
 @media (max-width: 768px) {
-  .header-nav { display: none; }
+  .header-nav {
+    display: none;
+  }
+
+  .hamburger-btn {
+    display: flex;
+  }
+
+  .mobile-nav {
+    display: flex;
+  }
+
+  .mobile-overlay {
+    display: block;
+  }
 }
 </style>

--- a/frontend/src/components/ChatBubble.vue
+++ b/frontend/src/components/ChatBubble.vue
@@ -171,4 +171,11 @@ function formatTime(ts: number) {
   color: var(--text-muted);
   padding: 0 4px;
 }
+
+@media (max-width: 640px) {
+  .bubble__body { max-width: 90%; }
+  .bubble__body pre { max-width: 100%; overflow-x: auto; }
+  .bubble__body code { word-break: break-word; overflow-wrap: break-word; }
+  .bubble__refs { flex-wrap: wrap; }
+}
 </style>

--- a/frontend/src/components/MarkdownView.vue
+++ b/frontend/src/components/MarkdownView.vue
@@ -200,3 +200,10 @@ watch(parsedBlocks, (blocks) => {
 .code-ref-chip__info { opacity: 0.7; }
 .code-ref-chip svg { width: 13px; height: 13px; }
 </style>
+
+<style scoped>
+.markdown-view {
+  overflow-x: hidden;
+  max-width: 100%;
+}
+</style>

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -14,6 +14,10 @@ const route = useRoute()
 const router = useRouter()
 const chatStore = useChatStore()
 
+// Mobile detection
+const isMobile = ref(window.innerWidth <= 1024)
+function handleResize() { isMobile.value = window.innerWidth <= 1024 }
+
 function generateId(): string {
   if (typeof crypto !== 'undefined' && typeof (crypto as Crypto).randomUUID === 'function') {
     return (crypto as Crypto).randomUUID()
@@ -400,6 +404,7 @@ function highlightCode(code: string, lang: string): string {
 }
 
 onMounted(async () => {
+  window.addEventListener('resize', handleResize)
   const q = route.query.q as string | undefined
   const dr = route.query.dr === '1'
 
@@ -424,6 +429,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  window.removeEventListener('resize', handleResize)
   if (drContinueTimer) clearTimeout(drContinueTimer)
   if (activeEventSource) activeEventSource.close()
   if (activeAbortController) activeAbortController.abort()
@@ -499,7 +505,7 @@ onUnmounted(() => {
               v-for="msg in chatStore.messages"
               :key="msg.id"
               :message="msg"
-              :compact-code="true"
+              :compact-code="!isMobile"
               @ref-click="loadFilePanel"
               @code-blocks="handleCodeBlocks"
               @code-block-focus="handleCodeBlockFocus"
@@ -1034,6 +1040,15 @@ onUnmounted(() => {
 @media (max-width: 1024px) {
   .chat-left { flex: 0 0 100%; }
   .code-panel { display: none; }
+}
+
+@media (max-width: 640px) {
+  .chat-header { padding: 0 12px; height: 44px; }
+  .chat-title { font-size: 14px; }
+  .chat-messages { padding: 12px; }
+  .chat-empty { padding: 40px 16px; }
+  .suggestion-chip { font-size: 11px; padding: 5px 10px; }
+  .back-btn span { display: none; }
 }
 
 /* ── Deep Research Progress Card ───────────────────────── */

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -714,8 +714,16 @@ async function handleSubmit() {
 
 /* ── Responsive ───────────────────────────────────── */
 @media (max-width: 640px) {
+  .home-view { padding-top: 24px; }
   .url-input-row { flex-direction: column; }
   .form-row { grid-template-columns: 1fr; }
-  .hero__title { font-size: 2rem; }
+  .hero__title { font-size: 1.75rem; }
+  .hero__subtitle { font-size: 0.9rem; }
+  .task-banner { word-break: break-word; }
+  .features { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 380px) {
+  .hero__title { font-size: 1.5rem; }
 }
 </style>

--- a/frontend/src/views/RepoListView.vue
+++ b/frontend/src/views/RepoListView.vue
@@ -946,6 +946,59 @@ onMounted(async () => {
 @media (max-width: 640px) {
   .repo-grid { grid-template-columns: 1fr; }
   .page-header { flex-direction: column; gap: 16px; }
+  .page-title { font-size: var(--font-size-xl); }
+  .page-header .btn { width: 100%; justify-content: center; }
+
+  /* Form rows collapse to single column inside modals */
+  .form-row { grid-template-columns: 1fr; }
+
+  /* Modals get constrained height and proper mobile padding */
+  .modal {
+    max-height: 90vh;
+    overflow-y: auto;
+    padding: 20px 16px;
+  }
+  .sync-modal {
+    max-width: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
+    padding: 20px 16px;
+  }
+
+  /* Commit grid collapses to single column */
+  .commit-item {
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+  }
+  .commit-meta {
+    grid-column: 1 / -1;
+    padding-top: 2px;
+  }
+
+  /* Action buttons get adequate touch target size */
+  .repo-card__actions { gap: 8px; }
+  .repo-card__actions .btn { min-height: 36px; }
+
+  /* Filter bar wraps on small screens */
+  .filter-bar { flex-direction: column; align-items: flex-start; }
+  .filter-group { flex-wrap: wrap; }
+}
+
+@media (max-width: 480px) {
+  .repo-list-view { padding: 20px 12px 60px; }
+
+  /* URL text breaks to prevent overflow */
+  .repo-card__url {
+    white-space: normal;
+    word-break: break-all;
+  }
+
+  /* Ensure URL input is full width inside modals */
+  .modal .form-input,
+  .sync-modal .form-input { width: 100%; box-sizing: border-box; }
+
+  /* Modal overlay reduces padding so modal fills screen better */
+  .modal-overlay { padding: 12px; }
 }
 
 /* ── Sync modal advanced options ──────────────────── */

--- a/frontend/src/views/SystemView.vue
+++ b/frontend/src/views/SystemView.vue
@@ -1829,4 +1829,41 @@ onMounted(() => {
 
 .test-result--ok { color: var(--color-success, #16a34a); }
 .test-result--err { color: var(--color-error, #dc2626); }
+
+/* ── Mobile improvements ──────────────────────────────────────────────────── */
+
+/* Storage card path text can overflow on mobile */
+.storage-card__path { word-break: break-all; white-space: normal; }
+
+@media (max-width: 640px) {
+  /* Reduce top padding */
+  .system-view { padding: 20px 16px 60px; }
+  .page-title { font-size: var(--font-size-xl); }
+
+  /* Config card fills width */
+  .config-card { max-width: 100%; }
+
+  /* Tab bar touch scrolling, hide scrollbar, compact buttons */
+  .tab-bar { -webkit-overflow-scrolling: touch; }
+  .tab-bar::-webkit-scrollbar { display: none; }
+  .tab-btn { padding: 10px 14px; font-size: 12px; }
+  .tab-btn .tab-icon { display: none; }
+
+  /* Test row wraps on mobile */
+  .test-row { flex-wrap: wrap; }
+  .test-model-input { max-width: 100%; width: 100%; flex: none; }
+  .test-result { width: 100%; max-width: 100%; overflow: visible; white-space: normal; }
+
+  /* Task table compact on mobile */
+  .task-table th,
+  .task-table td { padding: 8px 10px; font-size: 11px; }
+  .td-date { display: none; }
+  .td-progress { min-width: 80px; }
+}
+
+@media (max-width: 480px) {
+  /* Cleanup button full width on very small screens */
+  .cleanup-header { flex-direction: column; }
+  .cleanup-header .btn { width: 100%; justify-content: center; }
+}
 </style>

--- a/frontend/src/views/WikiView.vue
+++ b/frontend/src/views/WikiView.vue
@@ -870,12 +870,56 @@ watch(() => wikiStore.activePageId, async () => {
 
 @media (max-width: 768px) {
   .wiki-toc { display: none; }
-  .wiki-content-body { padding: 16px 20px; }
-  .mobile-menu-btn { display: flex; }
-  .wiki-chat-bar { left: 0; padding: 12px 16px 20px; }
-  .wiki-toolbar { padding: 0 12px; }
+  .wiki-content-body { padding: 16px 16px; }
+  .mobile-menu-btn {
+    display: flex;
+    width: 36px;
+    height: 36px;
+  }
+  .wiki-chat-bar { left: 0; right: 0; padding: 12px 16px 20px; }
+  .wiki-toolbar { padding: 0 8px; }
   :deep(.sidebar--mobile-open) {
     transform: translateX(0) !important;
+  }
+
+  /* Hide toolbar text labels, keep icons */
+  .toolbar-btn span:not(.toolbar-btn__hint) {
+    display: none;
+  }
+
+  /* Hide keyboard shortcut hints */
+  .toolbar-btn__hint { display: none; }
+
+  /* Minimum 36px touch target for toolbar buttons */
+  .toolbar-btn {
+    min-width: 36px;
+    min-height: 36px;
+    padding: 6px 8px;
+    justify-content: center;
+  }
+
+  /* More prominent hamburger button */
+  .mobile-menu-btn {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius);
+    color: var(--text-secondary);
+  }
+  .mobile-menu-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+  .mobile-menu-btn svg { width: 20px; height: 20px; }
+
+  /* Breadcrumb should not overflow */
+  .wiki-breadcrumb {
+    font-size: 12px;
+  }
+  .breadcrumb-item:first-child {
+    display: none;
+  }
+  .breadcrumb-sep {
+    display: none;
   }
 }
 


### PR DESCRIPTION
- AppHeader：新增汉堡菜单与移动端导航抽屉（768px 以下）
- main.css：修复代码块溢出，行内 code 加 word-break，表格横滑支持
- HomeView：移动端顶部间距与标题字号优化
- RepoListView：Modal、URL 溢出、触控按钮移动端适配
- SystemView：Tab 横滑、测试行换行、任务表格窄屏优化
- WikiView：工具栏移动端仅显示图标，聊天栏延伸全宽
- ChatView：isMobile 响应式，代码块在移动端内联渲染
- ChatBubble：气泡宽度扩至 90%，代码块横滑保护
- MarkdownView：内容容器 overflow-x: hidden 防止横向页面滚动